### PR TITLE
fix: group mapping

### DIFF
--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -50,8 +50,8 @@ async def async_setup(hass: HomeAssistant, config):
 
     _LOGGER.info("Registered OIDC provider")
 
-    # We only use openid & profile, never email
-    scope = "openid profile"
+    # We only use openid, profile & groups, never email
+    scope = "openid profile groups"
 
     oidc_client = oidc_client = OIDCClient(
         discovery_url=my_config.get(DISCOVERY_URL),

--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -259,7 +259,7 @@ class OpenIDAuthProvider(AuthProvider):
         sub = credentials.data["sub"]
         meta = self._user_meta.get(sub, {})
 
-        groups = meta.get("groups", [])
+        groups = meta.get("groups") or []
 
         # TODO: Allow setting which group is for admins
         group = "system-admin" if "admins" in groups else "system-users"


### PR DESCRIPTION
Hi, I was able to login using Authelia after changing a few things about groups:

- Add `groups` scope to fetch the user's groups (used by the OIDC auth provider)
- Handle cases where `meta.get("groups")` returns None