### PR TITLE
feat: enable verification of certs via `network.tls_verify` and priva…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ With the default configuration, [a person entry](https://www.home-assistant.io/i
 | `claims.groups`            | `string` | No       | `groups`                     | The claim to use to obtain the user's group(s). |
 | `roles.admin`            | `string` | No       | `admins`                     | Group name to require for users to get the 'admin' role in Home Assistant. Defaults to 'admins', the default group name for admins in Authentik. Doesn't do anything if no groups claim is found in your token. |
 | `roles.user`            | `string` | No       |                     | Group name to require for users to get the 'user' role in Home Assistant. Defaults to giving all users this role, unless configured. |
+| `network.tls_verify`         | `boolean` | No       | `true`                     | Verify TLS certificate. You may want to set this set to `false` when testing locally. |
+| `network.tls_ca_path`            | `string` | No       |                       | Path to file containing a private certificate authority chain. |
 
 #### Example: Migrating from HA username/password users to OIDC users
 If you already have users created within Home Assistant and would like to re-use the current user profile for your OIDC login, you can (temporarily) enable `features.automatic_user_linking`, with the following config (example):
@@ -87,6 +89,26 @@ Upon login, OIDC users will then automatically be linked to the HA user with the
 
 > [!IMPORTANT]
 > It's recommended to only enable this temporarily as it may pose a security risk. Any OIDC user with a username corresponding to a user in Home Assistant can get access to that user, and it's existing rights (admin), even if MFA is currently enabled for that account. After you have migrated your users (and linked OIDC to all existing accounts) you can disable the feature and keep using the linked users.
+
+#### Example: Using a private certificate authority
+If you use a private certificate authority to secure your OIDC provider (e.g. Keycloak), your CA must be able to be used by this component. Otherwise you will receive a certificate error (`[SSL: CERTIFICATE_VERIFY_FAILED]`) when connecting to the OIDC provider.
+You can either make the CA known to the entire operating system or configure only this component to use the CA. If you only want to let this component know your CA, you can specify it via `network.tls_ca_path`:
+
+```yaml
+auth_oidc:
+    network:
+        tls_ca_path: /path/to/private-ca.pem
+```
+
+If you want to deactivate the validation of the certificates for test purposes, you can do this via `network.tls_verify: false`:
+
+```yaml
+auth_oidc:
+    network:
+        tls_verify: false
+```
+
+In productive use, however, you should set `network.tls_verify` to `true`.
 
 ## Development
 This project uses the Rye package manager for development. You can find installation instructions here: https://rye.astral.sh/guide/installation/.

--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -19,6 +19,7 @@ from .config import (
     FEATURES,
     CLAIMS,
     ROLES,
+    NETWORK,
 )
 
 # pylint: enable=useless-import-alias
@@ -55,6 +56,7 @@ async def async_setup(hass: HomeAssistant, config):
     scope = "openid profile groups"
 
     oidc_client = oidc_client = OIDCClient(
+        hass=hass,
         discovery_url=my_config.get(DISCOVERY_URL),
         client_id=my_config.get(CLIENT_ID),
         scope=scope,
@@ -63,6 +65,7 @@ async def async_setup(hass: HomeAssistant, config):
         features=my_config.get(FEATURES, {}),
         claims=my_config.get(CLAIMS, {}),
         roles=my_config.get(ROLES, {}),
+        network=my_config.get(NETWORK, {}),
     )
 
     # Register the views

--- a/custom_components/auth_oidc/config.py
+++ b/custom_components/auth_oidc/config.py
@@ -19,6 +19,10 @@ ROLES = "roles"
 ROLE_ADMINS = "admin"
 ROLE_USERS = "user"
 
+NETWORK = "network"
+NETWORK_TLS_VERIFY = "tls_verify"
+NETWORK_TLS_CA_PATH = "tls_ca_path"
+
 DEFAULT_TITLE = "OpenID Connect (SSO)"
 
 DOMAIN = "auth_oidc"
@@ -76,6 +80,17 @@ CONFIG_SCHEMA = vol.Schema(
                         # What group name should we use to assign the admin role?
                         # Defaults to admins
                         vol.Optional(ROLE_ADMINS): vol.Coerce(str),
+                    }
+                ),
+                # Network options
+                vol.Optional(NETWORK): vol.Schema(
+                    {
+                        # Verify x509 certificates provided when starting TLS connections
+                        vol.Optional(NETWORK_TLS_VERIFY, default=True): vol.Coerce(
+                            bool
+                        ),
+                        # Load custom certificate chain for private CAs
+                        vol.Optional(NETWORK_TLS_CA_PATH): vol.Coerce(str),
                     }
                 ),
             }


### PR DESCRIPTION
feat: enable verification of certs via `network.tls_verify` and privte CA chains with `network.tls_ca_path`

This patch allows us 
- to use `network.tls_verify = true|false` or enable or disable x509 certificate verfication
- setting `network.tls_ca_path  <path>` to a custom CA bundle when using a private Certificate Authority.