### PR TITLE
Add configurable group names for roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ With the default configuration, [a person entry](https://www.home-assistant.io/i
 | `claims.display_name`      | `string` | No       | `name`                     | The claim to use to obtain the display name.
 | `claims.username`         | `string` | No       | `preferred_username`                     | The claim to use to obtain the username.
 | `claims.groups`            | `string` | No       | `groups`                     | The claim to use to obtain the user's group(s). |
+| `roles.admin`            | `string` | No       | `admins`                     | Group name to require for users to get the 'admin' role in Home Assistant. Defaults to 'admins', the default group name for admins in Authentik. Doesn't do anything if no groups claim is found in your token. |
+| `roles.user`            | `string` | No       |                     | Group name to require for users to get the 'user' role in Home Assistant. Defaults to giving all users this role, unless configured. |
 
 #### Example: Migrating from HA username/password users to OIDC users
 If you already have users created within Home Assistant and would like to re-use the current user profile for your OIDC login, you can (temporarily) enable `features.automatic_user_linking`, with the following config (example):

--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -18,6 +18,7 @@ from .config import (
     ID_TOKEN_SIGNING_ALGORITHM,
     FEATURES,
     CLAIMS,
+    ROLES,
 )
 
 # pylint: enable=useless-import-alias
@@ -61,6 +62,7 @@ async def async_setup(hass: HomeAssistant, config):
         id_token_signing_alg=my_config.get(ID_TOKEN_SIGNING_ALGORITHM),
         features=my_config.get(FEATURES, {}),
         claims=my_config.get(CLAIMS, {}),
+        roles=my_config.get(ROLES, {}),
     )
 
     # Register the views

--- a/custom_components/auth_oidc/config.py
+++ b/custom_components/auth_oidc/config.py
@@ -15,6 +15,9 @@ CLAIMS = "claims"
 CLAIMS_DISPLAY_NAME = "display_name"
 CLAIMS_USERNAME = "username"
 CLAIMS_GROUPS = "groups"
+ROLES = "roles"
+ROLE_ADMINS = "admin"
+ROLE_USERS = "user"
 
 DEFAULT_TITLE = "OpenID Connect (SSO)"
 
@@ -61,6 +64,18 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(CLAIMS_USERNAME): vol.Coerce(str),
                         # Which claim should we use to obtain the group(s) from OIDC?
                         vol.Optional(CLAIMS_GROUPS): vol.Coerce(str),
+                    }
+                ),
+                # Determine which specific group values will be mapped to which roles
+                # Optional, defaults user = null, admin = 'admins'
+                # If user role is set, users that do not have either will be rejected!
+                vol.Optional(ROLES): vol.Schema(
+                    {
+                        # Which group name should we use to assign the user role?
+                        vol.Optional(ROLE_USERS): vol.Coerce(str),
+                        # What group name should we use to assign the admin role?
+                        # Defaults to admins
+                        vol.Optional(ROLE_ADMINS): vol.Coerce(str),
                     }
                 ),
             }

--- a/custom_components/auth_oidc/endpoints/callback.py
+++ b/custom_components/auth_oidc/endpoints/callback.py
@@ -52,5 +52,15 @@ class OIDCCallbackView(HomeAssistantView):
             )
             return web.Response(text=view_html, content_type="text/html")
 
+        if user_details.get("role") == "invalid":
+            view_html = await get_view(
+                "error",
+                {
+                    "error": "User is not in the correct group to access Home Assistant, "
+                    + "contact your administrator!",
+                },
+            )
+            return web.Response(text=view_html, content_type="text/html")
+
         code = await self.oidc_provider.async_save_user_info(user_details)
         return web.HTTPFound(get_url("/auth/oidc/finish?code=" + code))

--- a/custom_components/auth_oidc/endpoints/finish.py
+++ b/custom_components/auth_oidc/endpoints/finish.py
@@ -46,9 +46,9 @@ class OIDCFinishView(HomeAssistantView):
                 # Set a cookie to enable autologin on only the specific path used
                 # for the POST request, with all strict parameters set
                 # This cookie should not be read by any Javascript or any other paths.
-                # It can be really short lifetime as we redirect immediately (15 seconds)
+                # It can be really short lifetime as we redirect immediately (5 seconds)
                 "set-cookie": "auth_oidc_code="
                 + code
-                + "; Path=/auth/login_flow; SameSite=Strict; HttpOnly; Max-Age=15",
+                + "; Path=/auth/login_flow; SameSite=Strict; HttpOnly; Max-Age=5",
             },
         )

--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -259,14 +259,11 @@ class OpenIDAuthProvider(AuthProvider):
         sub = credentials.data["sub"]
         meta = self._user_meta.get(sub, {})
 
-        groups = meta.get("groups") or []
-
-        # TODO: Allow setting which group is for admins
-        group = "system-admin" if "admins" in groups else "system-users"
+        role = meta.get("role")
         return UserMeta(
             name=meta.get("display_name"),
             is_active=True,
-            group=group,
+            group=role,
             local_only=False,
         )
 

--- a/custom_components/auth_oidc/types.py
+++ b/custom_components/auth_oidc/types.py
@@ -1,7 +1,9 @@
 """Generic data types"""
 
-
 # Dict class to give a type to the user details
+from typing import Literal
+
+
 class UserDetails(dict):
     """User details representation"""
 
@@ -12,5 +14,5 @@ class UserDetails(dict):
     # Preferred username for the user, will be used when first generating the account
     # or to link the account on first login
     username: str
-    # Groups that the user has, if any are sent from the OIDC provider
-    groups: list[str]
+    # Home Assistant role to assign to this user
+    role: Literal["system-admin", "system-users", "invalid"]


### PR DESCRIPTION
Adds the config variables `roles.admin` and `roles.user` which allow setting group names to require for either role.
Defaults to the configuration in previous versions.