### PR TITLE
Add configurable welcome and redirect paths for OIDC endpoints in Home Assistant

### DIFF
--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -24,7 +24,7 @@ from .config import (
     FEATURES_INCLUDE_GROUPS_SCOPE,
     FEATURES_WELCOME_PATH,
     FEATURES_REDIRECT_PATH,
-    )
+)
 
 # pylint: enable=useless-import-alias
 

--- a/custom_components/auth_oidc/config.py
+++ b/custom_components/auth_oidc/config.py
@@ -13,6 +13,8 @@ FEATURES_AUTOMATIC_USER_LINKING = "automatic_user_linking"
 FEATURES_AUTOMATIC_PERSON_CREATION = "automatic_person_creation"
 FEATURES_DISABLE_PKCE = "disable_rfc7636"
 FEATURES_INCLUDE_GROUPS_SCOPE = "include_groups_scope"
+FEATURES_WELCOME_PATH = "welcome_path"
+FEATURES_REDIRECT_PATH = "redirect_path"
 CLAIMS = "claims"
 CLAIMS_DISPLAY_NAME = "display_name"
 CLAIMS_USERNAME = "username"
@@ -65,6 +67,9 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(
                             FEATURES_INCLUDE_GROUPS_SCOPE, default=True
                         ): vol.Coerce(bool),
+                         # Optional paths for welcome and redirect endpoints
+                        vol.Optional(FEATURES_WELCOME_PATH, default="/auth/oidc/welcome"): vol.Coerce(str),
+                        vol.Optional(FEATURES_REDIRECT_PATH, default="/auth/oidc/redirect"): vol.Coerce(str),
                     }
                 ),
                 # Determine which specific claims will be used from the id_token

--- a/custom_components/auth_oidc/config.py
+++ b/custom_components/auth_oidc/config.py
@@ -67,9 +67,13 @@ CONFIG_SCHEMA = vol.Schema(
                         vol.Optional(
                             FEATURES_INCLUDE_GROUPS_SCOPE, default=True
                         ): vol.Coerce(bool),
-                         # Optional paths for welcome and redirect endpoints
-                        vol.Optional(FEATURES_WELCOME_PATH, default="/auth/oidc/welcome"): vol.Coerce(str),
-                        vol.Optional(FEATURES_REDIRECT_PATH, default="/auth/oidc/redirect"): vol.Coerce(str),
+                        # Optional paths for welcome and redirect endpoints
+                        vol.Optional(
+                            FEATURES_WELCOME_PATH, default="/auth/oidc/welcome"
+                        ): vol.Coerce(str),
+                        vol.Optional(
+                            FEATURES_REDIRECT_PATH, default="/auth/oidc/redirect"
+                        ): vol.Coerce(str),
                     }
                 ),
                 # Determine which specific claims will be used from the id_token

--- a/custom_components/auth_oidc/endpoints/redirect.py
+++ b/custom_components/auth_oidc/endpoints/redirect.py
@@ -7,6 +7,7 @@ from homeassistant.components.http import HomeAssistantView
 from ..oidc_client import OIDCClient
 from ..helpers import get_url, get_view
 
+
 class OIDCRedirectView(HomeAssistantView):
     """OIDC Plugin Redirect View."""
 

--- a/custom_components/auth_oidc/endpoints/redirect.py
+++ b/custom_components/auth_oidc/endpoints/redirect.py
@@ -7,18 +7,15 @@ from homeassistant.components.http import HomeAssistantView
 from ..oidc_client import OIDCClient
 from ..helpers import get_url, get_view
 
-PATH = "/auth/oidc/redirect"
-
-
 class OIDCRedirectView(HomeAssistantView):
     """OIDC Plugin Redirect View."""
 
     requires_auth = False
-    url = PATH
-    name = "auth:oidc:redirect"
 
-    def __init__(self, oidc_client: OIDCClient) -> None:
+    def __init__(self, oidc_client: OIDCClient, path: str) -> None:
         self.oidc_client = oidc_client
+        self.url = path
+        self.name = "auth:oidc:redirect"
 
     async def get(self, _: web.Request) -> web.Response:
         """Receive response."""

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -4,18 +4,15 @@ from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from ..helpers import get_view
 
-PATH = "/auth/oidc/welcome"
-
-
 class OIDCWelcomeView(HomeAssistantView):
     """OIDC Plugin Welcome View."""
 
     requires_auth = False
-    url = PATH
-    name = "auth:oidc:welcome"
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, path: str) -> None:
         self.name = name
+        self.url = path
+        self.name = "auth:oidc:welcome"
 
     async def get(self, _: web.Request) -> web.Response:
         """Receive response."""

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -10,12 +10,34 @@ class OIDCWelcomeView(HomeAssistantView):
 
     requires_auth = False
 
-    def __init__(self, name: str, path: str) -> None:
+    def __init__(self, name: str, path: str, redirect_path: str) -> None:
+        """Initialize the OIDC Welcome View.
+
+        Args:
+            name (str): The name of the view.
+            path (str): The URL path for the view.
+            redirect_path (str): The URL path for the redirect.
+        """
         self.name = name
         self.url = path
+        self.redirect_url = redirect_path
         self.name = "auth:oidc:welcome"
 
-    async def get(self, _: web.Request) -> web.Response:
-        """Receive response."""
-        view_html = await get_view("welcome", {"name": self.name})
-        return web.Response(text=view_html, content_type="text/html")
+    async def get(self, request: web.Request) -> web.Response:
+        """Handle GET requests.
+
+        Args:
+            request (web.Request): The incoming request.
+
+        Returns:
+            web.Response: The response to be sent back to the client.
+        """
+        try:
+            view_html = await get_view(
+                "welcome", {"name": self.name, "redirect_url": self.redirect_url}
+            )
+            return web.Response(text=view_html, content_type="text/html")
+        except Exception as e:
+            # Log the error and return an error response
+            self._logger.error(f"Error in OIDCWelcomeView: {e}")
+            return web.Response(text="An error occurred", status=500)

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -4,6 +4,7 @@ from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from ..helpers import get_view
 
+
 class OIDCWelcomeView(HomeAssistantView):
     """OIDC Plugin Welcome View."""
 

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -32,6 +32,7 @@ class OIDCWelcomeView(HomeAssistantView):
         Returns:
             web.Response: The response to be sent back to the client.
         """
+
         try:
             view_html = await get_view(
                 "welcome", {"name": self.name, "redirect_url": self.redirect_url}

--- a/custom_components/auth_oidc/templates/welcome.html
+++ b/custom_components/auth_oidc/templates/welcome.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome to OIDC</title>
+</head>
+<body>
+    <h1>Welcome to OIDC</h1>
+    <p>Click the button below to log in with OIDC.</p>
+    <a href="{{ redirect_url }}"><button>Log in with OIDC</button></a>
+</body>
+</html>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,14 +124,16 @@ Here's a table of all options that you can set:
 | `client_secret`            | `string` | No       |                      | The Client Secret for enabling confidential client mode.                                             |
 | `discovery_url`            | `string` | Yes      |                      | The OIDC well-known configuration URL.                                                                |
 | `display_name`              | `string` | No       | `"OpenID Connect (SSO)"` | The name to display on the login screen, both for the Home Assistant screen and the OIDC welcome screen.                                                                |
-| `id_token_signing_alg`       | `string` | No       | `RS256`              | The signing algorithm that is used for your id_tokens.
-| `groups_scope`  | `string` | No       | `groups`           | Override the default grups scope with another scope of your choice. |
+| `id_token_signing_alg`       | `string` | No       | `RS256`              | The signing algorithm that is used for your id_tokens.                                                |
+| `groups_scope`              | `string` | No       | `groups`             | Override the default groups scope with another scope of your choice.                                   |
 | `features.automatic_user_linking`   | `boolean`| No       | `false`          | Automatically links users to existing Home Assistant users based on the OIDC username claim. Disabled by default for security. When disabled, OIDC users will get their own new user profile upon first login.     |
 | `features.automatic_person_creation` | `boolean` | No       | `true`          | Automatically creates a person entry for new user profiles created by this integration. Recommended if you would like to assign presence detection to OIDC users.                                            |
 | `features.disable_rfc7636`  | `boolean`| No       | `false`         | Disables PKCE (RFC 7636) for OIDC providers that don't support it. You should not need this with most providers.                                    |
 | `features.include_groups_scope`  | `boolean` | No       | `true`           | Include the 'groups' scope in the OIDC request. Set to `false` to exclude it. |
-| `claims.display_name`      | `string` | No       | `name`                     | The claim to use to obtain the display name.
-| `claims.username`         | `string` | No       | `preferred_username`                     | The claim to use to obtain the username.
+| `features.welcome_path`  | `string` | No       | `/auth/oidc/welcome`           | Custom path for the OIDC Welcome endpoint. |
+| `features.redirect_path`  | `string` | No       | `/auth/oidc/redirect`           | Custom path for the OIDC Redirect endpoint. |
+| `claims.display_name`      | `string` | No       | `name`                     | The claim to use to obtain the display name. |
+| `claims.username`         | `string` | No       | `preferred_username`                     | The claim to use to obtain the username. |
 | `claims.groups`            | `string` | No       | `groups`                     | The claim to use to obtain the user's group(s). |
 | `roles.admin`            | `string` | No       | `admins`                     | Group name to require for users to get the 'admin' role in Home Assistant. Defaults to 'admins', the default group name for admins in Authentik. Doesn't do anything if no groups claim is found in your token. |
 | `roles.user`            | `string` | No       |                     | Group name to require for users to get the 'user' role in Home Assistant. Defaults to giving all users this role, unless configured. |


### PR DESCRIPTION
Pull Request: Configurable Paths for OIDC Welcome and Redirect Endpoints in Home Assistant

Summary
This Pull Request adds the ability to configure the paths for the OIDC Welcome and Redirect endpoints through the configuration file. If the paths are not specified in the configuration, default values will be used.

Changes Made
Configuration Schema Update:

Added optional configuration options for welcome_path and redirect_path in [config.py](vscode-file://vscode-app/c:/Users/t.koelsch/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
These options allow users to specify custom paths for the OIDC Welcome and Redirect endpoints.

Welcome Endpoint Update:
Modified welcome.py to accept the path as a parameter in the constructor and use it.

Redirect Endpoint Update:
Modified redirect.py to accept the path as a parameter in the constructor and use it.

Initialization Update:
Modified __init__.py to read the custom paths from the configuration and pass them to the constructors of the OIDCWelcomeView and OIDCRedirectView.

Documentation
Updated the configuration schema to include the new optional paths.
Added comments to the code to explain the changes and how the paths are read from the configuration.