### PR TITLE
Fix Username matching when idP has uppercase letters in username

### DIFF
--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -139,7 +139,7 @@ class OpenIDAuthProvider(AuthProvider):
             for credential in user.credentials:
                 if (
                     credential.auth_provider_type == HASS_PROVIDER_TYPE
-                    and credential.data.get("username") == username
+                    and credential.data.get("username") == username.lower()
                 ):
                     return user
 


### PR DESCRIPTION
Issue arises when username such as `Abc` instead of `abc` in their chosen username, this does a dirty fix to get oidc within Home Assistant username compliance.