### PR TITLE
Improve the JS for SSO

### DIFF
--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -131,7 +131,7 @@ observer.observe(document.body, { childList: true, subtree: true })
 
 setTimeout(() => {
   if (!ready) {
-    console.warn("hass-oidc-auth: Document was not ready after 500ms seconds, force displaying. This may indicate a problem with the UI injection.")
+    console.warn("hass-oidc-auth: Document was not ready after 300ms seconds, force displaying. This may indicate a problem with the UI injection.")
   }
   document.querySelector(".content").style.display = "";
   update();

--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -1,27 +1,42 @@
 function safeSetTextContent(element, value) {
   if (!element) return
   var textNode = Array.from(element.childNodes).find(node => node.nodeType === Node.TEXT_NODE && node.textContent.trim().length > 0)
-  if (!textNode) return
+  if (!textNode || textNode.textContent === value) return
   textNode.textContent = value
 }
 
+let firstFocus = true
+
 function addSSOButton() {
   const loginHeader = document.querySelector(".card-content > ha-auth-flow > form > h1")
-  safeSetTextContent(loginHeader, "Log in to Home Assistant")
-  
   const codeField = document.querySelector(".mdc-text-field__input[name=code]")
   const loginButton = document.querySelector("mwc-button:not(.sso)")
+  const ssoButton = document.querySelector("mwc-button.sso")
 
-  if (codeField) {
+  safeSetTextContent(loginHeader, "Log in to Home Assistant")
+
+  if (codeField && codeField.placeholder !== "One-time code") {
     codeField.placeholder = "One-time code"
     codeField.autofocus = false
     codeField.autocomplete = "off"
-    setTimeout(() => {
-      codeField.blur()
-    }, 0)
+    if (firstFocus) {
+      firstFocus = false
+      if (document.activeElement === codeField) {
+        setTimeout(() => {
+          codeField.blur()
+          setTimeout(() => {
+            const helperText = document.querySelector("#helper-text")
+            const invalidTextField = document.querySelector(".mdc-text-field--invalid")
+            const validationMsg = document.querySelector(".mdc-text-field-helper-text--validation-msg")
+            if (helperText) safeSetTextContent(helperText, "")
+            if (invalidTextField) invalidTextField.classList.remove("mdc-text-field--invalid")
+            if (validationMsg) validationMsg.classList.remove("mdc-text-field-helper-text--validation-msg")
+          }, 0)
+        }, 0)
+      }
+    }
   }
 
-  var ssoButton = document.querySelector("mwc-button.sso")
   if (!ssoButton) {
     ssoButton = document.createElement("mwc-button")
     ssoButton.classList.add("sso")
@@ -32,14 +47,16 @@ function addSSOButton() {
     ssoButton.addEventListener("click", () => {
       location.href = "/auth/oidc/redirect"
     })
-    loginButton.parentElement.prepend(ssoButton)
+    if (loginButton) loginButton.parentElement.prepend(ssoButton)
+  } else {
+    ssoButton.style.display = codeField ? "" : "none"
   }
 
   safeSetTextContent(loginButton, codeField ? "Log in with code" : "Log in")
-  ssoButton.style.display = codeField ? "" : "none"
 }
 
 const observer = new MutationObserver((mutationsList, observer) => {
   addSSOButton()
 })
+
 observer.observe(document.body, { childList: true, subtree: true })


### PR DESCRIPTION
This PR includes:

- Showing an error message when code login fails
- Only show code or sso login at a time (default to sso on desktop, code in the app)
- Add a message explaining how to get a login code (any suggestions for better wording would be appreciated)
- Hide the page content until we have loaded all our changes to avoid jumping the layout around (if it doesn't load in 300ms it displays anyways and logs a warning)

<img width="595" height="563" alt="image" src="https://github.com/user-attachments/assets/95ceb7af-4eff-44db-ba26-c89682e36096" />

<img width="462" height="683" alt="image" src="https://github.com/user-attachments/assets/a94b59c1-d75f-4b82-baaa-fb556bc3457b" />

<img width="486" height="647" alt="image" src="https://github.com/user-attachments/assets/c42357b7-7ff4-4c4f-adca-77de80c32f43" />
