### PR TITLE
Persist OIDC logins on HTTP refresh

### DIFF
--- a/custom_components/auth_oidc/endpoints/finish.py
+++ b/custom_components/auth_oidc/endpoints/finish.py
@@ -41,7 +41,7 @@ class OIDCFinishView(HomeAssistantView):
 
         # Return redirect to the main page for sign in with a cookie
         return web.HTTPFound(
-            location="/",
+            location="/?storeToken=true",
             headers={
                 # Set a cookie to enable autologin on only the specific path used
                 # for the POST request, with all strict parameters set


### PR DESCRIPTION
This relates to #70, where refreshing the webpage causes the user to need to login again, due to homeassistant not storing the user's session token `hassTokens`.