### PR TITLE
Fixes upstream changes to UI

### DIFF
--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -28,9 +28,9 @@ function update() {
   const loginHeader = document.querySelector(".card-content > ha-auth-flow > form > h1")
   const authForm = document.querySelector("ha-auth-form")
   const codeField = document.querySelector(".mdc-text-field__input[name=code]")
-  const loginButton = document.querySelector("mwc-button:not(.sso)")
+  const loginButton = document.querySelector("ha-button:not(.sso)")
   const errorAlert = document.querySelector("ha-auth-form ha-alert[alert-type=error]")
-  const loginOptionList = document.querySelector("ha-pick-auth-provider")?.shadowRoot?.querySelector("mwc-list")
+  const loginOptionList = document.querySelector("ha-pick-auth-provider")?.shadowRoot?.querySelector("ha-list")
 
   // ====
   // Code input
@@ -125,7 +125,7 @@ function update() {
   const isOurScreen = showCode() || shouldShowSSOButton
   
   if (loginButton && !ssoButton) {
-    ssoButton = document.createElement("mwc-button")
+    ssoButton = document.createElement("ha-button")
     ssoButton.id = "sso_button"
     ssoButton.classList.add("sso")
     ssoButton.innerText = "Log in with " + sso_name


### PR DESCRIPTION
The UI buttons for Home Assistant were moved from a `mwc-` prefix to a `ha-` prefix.

Fixes https://github.com/christiaangoossens/hass-oidc-auth/issues/109