### PR TITLE
fix: support HA 2026.4+ ha-input web components in injection.js selector

### DIFF
--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -28,7 +28,10 @@ function update() {
   const sso_name = window.sso_name || "Single Sign-On"
   const loginHeader = document.querySelector(".card-content > ha-auth-flow > form > h1")
   const authForm = document.querySelector("ha-auth-form")
+  // Support both old MDC text field (HA < 2026.4) and new ha-input web component (HA >= 2026.4)
   const codeField = document.querySelector(".mdc-text-field__input[name=code]")
+    || document.querySelector("ha-auth-form ha-input[type=text]")
+    || document.querySelector("ha-auth-form ha-auth-form-string ha-input")
   const haButtons = document.querySelectorAll("ha-button:not(.sso)")
   const errorAlert = document.querySelector("ha-auth-form ha-alert[alert-type=error]")
   const loginOptionList = document.querySelector("ha-pick-auth-provider")?.shadowRoot?.querySelector("ha-list")
@@ -45,7 +48,10 @@ function update() {
   // ====
   // Code input
   if (codeField) {
-    if (codeField.placeholder !== "One-time code") {
+    // Only manipulate placeholder/autofocus on old-style native <input> elements (MDC).
+    // New ha-input web components don't expose these properties directly.
+    const isNativeInput = codeField.tagName === 'INPUT'
+    if (isNativeInput && codeField.placeholder !== "One-time code") {
       codeField.placeholder = "One-time code"
       codeField.autofocus = false
       codeField.autocomplete = "off"


### PR DESCRIPTION
## Problem

On Home Assistant **2026.4.1**, the SSO "Log in with ..." button is **created but hidden** (`display: none`).

### Root Cause

HA 2026.4 replaced Material Design Components (MDC) text fields with custom `ha-input` web components. The login form now renders:

```html
<!-- HA 2026.4+ -->
<ha-auth-form>
  <ha-auth-form-string>
    <ha-input appearance="material" type="text">
      <!-- shadow DOM contains the actual input -->
    </ha-input>
  </ha-auth-form-string>
</ha-auth-form>
```

Instead of the previous:

```html
<!-- HA < 2026.4 -->
<ha-auth-form>
  <div class="mdc-text-field">
    <input class="mdc-text-field__input" name="code" />
  </div>
</ha-auth-form>
```

The `codeField` selector on line 31 — `.mdc-text-field__input[name=code]` — returns `null` on 2026.4+ because the element no longer exists. Since the SSO button's visibility depends on `codeField` being truthy (`ssoButton.style.display = (!showCode() && codeField) ? "" : "none"`), the button is always hidden.

### Symptoms

- SSO button element exists in the DOM but has `display: none`
- The 300ms timeout fires with the warning "Document was not ready after 300ms..."
- Page eventually shows the default HA login screen with no SSO option visible
- Manually navigating to `/auth/oidc/redirect` still works (backend is fine)

## Fix

Two changes:

### 1. Expanded `codeField` selector with fallbacks (line 31)

```javascript
// Before
const codeField = document.querySelector(".mdc-text-field__input[name=code]")

// After — try MDC first, fall back to ha-input web components
const codeField = document.querySelector(".mdc-text-field__input[name=code]")
  || document.querySelector("ha-auth-form ha-input[type=text]")
  || document.querySelector("ha-auth-form ha-auth-form-string ha-input")
```

The old MDC selector is tried first for backwards compatibility with HA versions prior to 2026.4.

### 2. Guard MDC-specific DOM manipulation (line 48)

```javascript
// Before — crashes or is a no-op on ha-input elements
if (codeField.placeholder !== "One-time code") {

// After — only manipulate native INPUT elements (MDC)
const isNativeInput = codeField.tagName === 'INPUT'
if (isNativeInput && codeField.placeholder !== "One-time code") {
```

The placeholder, autofocus, and autocomplete manipulation only makes sense on native `<input>` elements. `ha-input` web components don't expose these properties directly on the host element, and the old MDC-specific class manipulation (`mdc-text-field--invalid`, etc.) wouldn't find matching elements on 2026.4+ anyway.

## Testing

Tested on **Home Assistant 2026.4.1** (Python 3.14, aiohttp 3.13.5) with **hass-oidc-auth v0.7.0-alpha-rc5** and **Keycloak 26.0** as the OIDC provider.

**Before patch:** SSO button hidden, 300ms timeout warning in console.
**After patch:** SSO button visible and functional, OIDC redirect flow works correctly.

Backwards-compatible — the old MDC selector is still tried first, so older HA versions are unaffected.