### PR TITLE
Redirect native-picker click on OIDC provider to /auth/oidc/welcome (fix dead-end)

### DIFF
--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -59,8 +59,11 @@ class OpenIDAuthProvider(AuthProvider):
             {
                 # Currently register as default, might be used when we have multiple OIDC providers
                 CONF_ID: "default",
-                # Name displayed in the UI
-                CONF_NAME: config.get("display_name", DEFAULT_TITLE),
+                # Stable label for HA's native auth-picker row. Kept fixed so the
+                # frontend-injection script can match it without threading the
+                # user-configurable display_name through. The user's display_name
+                # is still rendered on the welcome page.
+                CONF_NAME: DEFAULT_TITLE,
                 # Type
                 CONF_TYPE: PROVIDER_TYPE,
             },

--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -1,21 +1,23 @@
 /**
- * hass-oidc-auth - injected UX script for /auth/authorize.
- * Auto-selects the OIDC provider when HA's login flow shows "Login aborted",
- * and redirects clicks on the OIDC provider row in the picker to
- * /auth/oidc/welcome (so the OIDC cookie gets set before async_step_init
- * fires, instead of dead-ending with no_oidc_cookie_found).
+ * Frontend helpers for /auth/authorize: auto-select on aborted login,
+ * and route picker clicks on our provider through /auth/oidc/welcome.
  */
 
 const OIDC_PROVIDER_NAME = "OpenID Connect (SSO)"  // matches provider.py CONF_NAME
 const OIDC_WELCOME_PATH = "/auth/oidc/welcome"
 
 let authFlowElement = null
-let pickerHijacked = false
+let pickerIntercepted = false
 
-function hijackPickerRow() {
-  if (pickerHijacked) return
-  const picker = document.querySelector('ha-pick-auth-provider')
-  const items = picker?.shadowRoot?.querySelectorAll('ha-list-item') || []
+function interceptPickerRow(authProviderElement) {
+  if (pickerIntercepted) return
+  if (!authProviderElement) return
+  if (!authProviderElement.shadowRoot) {
+    console.warn("[OIDC] ha-pick-auth-provider has no shadowRoot; HA frontend may have changed.")
+    return
+  }
+  const items = authProviderElement.shadowRoot.querySelectorAll('ha-list-item')
+  if (items.length === 0) return  // not yet populated; retry on next mutation
   for (const item of items) {
     if ((item.innerText || '').trim() !== OIDC_PROVIDER_NAME) continue
     item.addEventListener('click', (e) => {
@@ -25,42 +27,28 @@ function hijackPickerRow() {
         OIDC_WELCOME_PATH +
         '?redirect_uri=' + encodeURIComponent(btoa(window.location.href))
     }, true)
-    pickerHijacked = true
-    break
+    pickerIntercepted = true
+    return
   }
 }
 
 function update() {
-  // Find ha-auth-flow
   authFlowElement = document.querySelector('ha-auth-flow')
+  if (!authFlowElement) return
 
-  if (!authFlowElement) {
-    return
-  }
-
-  // Route a click on our provider row through the welcome flow so the
-  // OIDC state cookie gets set before async_step_init runs.
-  hijackPickerRow()
-
-  // Check if the text "Login aborted" is present on the page
-  if (!authFlowElement.innerText.includes('Login aborted')) {
-    return
-  }
-
-  // Find the ha-pick-auth-provider element
   const authProviderElement = document.querySelector('ha-pick-auth-provider')
 
-  if (!authProviderElement) {
-    return
-  }
+  // Intercept picker clicks so the OIDC cookie is set before submit.
+  interceptPickerRow(authProviderElement)
 
-  // Click the first ha-list-item element inside the ha-pick-auth-provider
+  // Auto-select on "Login aborted".
+  if (!authFlowElement.innerText.includes('Login aborted')) return
+  if (!authProviderElement) return
   const firstListItem = authProviderElement.shadowRoot?.querySelector('ha-list-item')
   if (!firstListItem) {
-    console.warn("[OIDC] No ha-list-item found inside ha-pick-auth-provider. Not automatically selecting HA provider.")
+    console.warn("[OIDC] No ha-list-item found inside ha-pick-auth-provider. Not automatically selecting OIDC provider.")
     return
   }
-
   firstListItem.click()
 }
 

--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -1,37 +1,67 @@
 /**
- * hass-oidc-auth - UX script to automatically select the Home Assistant auth provider when the "Login aborted" message is shown.
+ * hass-oidc-auth - injected UX script for /auth/authorize.
+ * Auto-selects the OIDC provider when HA's login flow shows "Login aborted",
+ * and redirects clicks on the OIDC provider row in the picker to
+ * /auth/oidc/welcome (so the OIDC cookie gets set before async_step_init
+ * fires, instead of dead-ending with no_oidc_cookie_found).
  */
 
+const OIDC_PROVIDER_NAME = "OpenID Connect (SSO)"  // matches provider.py CONF_NAME
+const OIDC_WELCOME_PATH = "/auth/oidc/welcome"
+
 let authFlowElement = null
+let pickerHijacked = false
+
+function hijackPickerRow() {
+  if (pickerHijacked) return
+  const picker = document.querySelector('ha-pick-auth-provider')
+  const items = picker?.shadowRoot?.querySelectorAll('ha-list-item') || []
+  for (const item of items) {
+    if ((item.innerText || '').trim() !== OIDC_PROVIDER_NAME) continue
+    item.addEventListener('click', (e) => {
+      e.stopImmediatePropagation()
+      e.preventDefault()
+      window.location.href =
+        OIDC_WELCOME_PATH +
+        '?redirect_uri=' + encodeURIComponent(btoa(window.location.href))
+    }, true)
+    pickerHijacked = true
+    break
+  }
+}
 
 function update() {
   // Find ha-auth-flow
-    authFlowElement = document.querySelector('ha-auth-flow');
+  authFlowElement = document.querySelector('ha-auth-flow')
 
-    if (!authFlowElement) {
-      return;
-    }
+  if (!authFlowElement) {
+    return
+  }
 
-    // Check if the text "Login aborted" is present on the page
-    if (!authFlowElement.innerText.includes('Login aborted')) {
-      return;
-    }
+  // Route a click on our provider row through the welcome flow so the
+  // OIDC state cookie gets set before async_step_init runs.
+  hijackPickerRow()
 
-    // Find the ha-pick-auth-provider element
-    const authProviderElement = document.querySelector('ha-pick-auth-provider');
+  // Check if the text "Login aborted" is present on the page
+  if (!authFlowElement.innerText.includes('Login aborted')) {
+    return
+  }
 
-    if (!authProviderElement) {
-      return;
-    }
+  // Find the ha-pick-auth-provider element
+  const authProviderElement = document.querySelector('ha-pick-auth-provider')
 
-    // Click the first ha-list-item element inside the ha-pick-auth-provider
-    const firstListItem = authProviderElement.shadowRoot?.querySelector('ha-list-item');
-    if (!firstListItem) {
-      console.warn("[OIDC] No ha-list-item found inside ha-pick-auth-provider. Not automatically selecting HA provider.");
-      return;
-    }
+  if (!authProviderElement) {
+    return
+  }
 
-    firstListItem.click();
+  // Click the first ha-list-item element inside the ha-pick-auth-provider
+  const firstListItem = authProviderElement.shadowRoot?.querySelector('ha-list-item')
+  if (!firstListItem) {
+    console.warn("[OIDC] No ha-list-item found inside ha-pick-auth-provider. Not automatically selecting HA provider.")
+    return
+  }
+
+  firstListItem.click()
 }
 
 // Hide the content until ready
@@ -58,4 +88,5 @@ setTimeout(() => {
 
   // Force display the content
   document.querySelector(".content").style.display = "";
+  update();
 }, 300)

--- a/tests/test_hass_auth_provider.py
+++ b/tests/test_hass_auth_provider.py
@@ -59,9 +59,8 @@ async def test_setup_success_auth_provider_registration(hass: HomeAssistant):
 
 @pytest.mark.asyncio
 async def test_provider_name_is_stable_regardless_of_display_name(hass: HomeAssistant):
-    """The auth provider's CONF_NAME is kept at DEFAULT_TITLE so the injected
-    frontend script can match the picker row by a stable label. The user's
-    configured display_name is still rendered on the welcome page."""
+    """CONF_NAME stays at DEFAULT_TITLE so injection.js can match the picker
+    row regardless of the configured display_name."""
     await setup(
         hass,
         {

--- a/tests/test_hass_auth_provider.py
+++ b/tests/test_hass_auth_provider.py
@@ -17,6 +17,8 @@ from custom_components.auth_oidc import DOMAIN
 from custom_components.auth_oidc.config.const import (
     DISCOVERY_URL,
     CLIENT_ID,
+    DEFAULT_TITLE,
+    DISPLAY_NAME,
     FEATURES,
     FEATURES_AUTOMATIC_PERSON_CREATION,
     FEATURES_AUTOMATIC_USER_LINKING,
@@ -53,6 +55,25 @@ async def test_setup_success_auth_provider_registration(hass: HomeAssistant):
 
     # Public auth-provider contract: OIDC provider does not support HA MFA
     assert auth_providers[0].support_mfa is False
+
+
+@pytest.mark.asyncio
+async def test_provider_name_is_stable_regardless_of_display_name(hass: HomeAssistant):
+    """The auth provider's CONF_NAME is kept at DEFAULT_TITLE so the injected
+    frontend script can match the picker row by a stable label. The user's
+    configured display_name is still rendered on the welcome page."""
+    await setup(
+        hass,
+        {
+            CLIENT_ID: "dummy",
+            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
+            DISPLAY_NAME: "Custom / Branded IdP",
+        },
+        True,
+    )
+
+    provider = hass.auth.get_auth_providers(DOMAIN)[0]
+    assert provider.name == DEFAULT_TITLE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #252

## Problem

On HA's native `/auth/authorize` picker (reachable via the welcome page's *"Use alternative sign-in method"* link, or any path that sets `skip_oidc_redirect=true`), clicking this plugin's provider row posts to `/auth/login_flow` and `async_step_init` aborts with `no_oidc_cookie_found`, because `auth_oidc_state` is only set by a prior visit to `/auth/oidc/welcome`. HA's login frontend then silently falls back to local auth — the picker row ends up as a dead-end rather than a way back into the SSO flow.

## Why not fix server-side

Tried returning `self.async_external_step(url="/auth/oidc/welcome")` from `async_step_init`. `LoginFlow` inherits the method from `FlowHandler`, but HA's login-flow UI silently ignores `type: external` and renders a "Start over" page on the same authorize URL. Only config-flow UIs handle `EXTERNAL_STEP`. Verified on v1.0.2 via CDP. So the fix has to live at the frontend layer this plugin already injects.

## What this PR does

1. **`provider.py`** pins `CONF_NAME` to `DEFAULT_TITLE`. The HA native picker row is labeled with a stable string, so the injected JS can match it without threading the user-configured `display_name` through. The welcome page button still shows `display_name` unchanged.
2. **`static/injection.js`** adds a small click interceptor (one function + one call, integrated into the existing `update()`) that, when it sees the picker row whose text equals `OIDC_PROVIDER_NAME` (= `DEFAULT_TITLE`), attaches a capture-phase click listener that redirects to `/auth/oidc/welcome?redirect_uri=encodeURIComponent(btoa(window.location.href))`. That matches the existing `welcome.py:_process_url` contract, so `storeToken` and `is_mobile` detection still work.
3. **`tests/test_hass_auth_provider.py`** adds `test_provider_name_is_stable_regardless_of_display_name`, which configures an exotic `display_name` and asserts `provider.name == DEFAULT_TITLE` — a regression guard on the invariant the JS matcher depends on.

No JSON blob injection, no normalization, no path guard, no `display_name` propagation. One cohesive script. Net: +79 / -24 across 3 files.

## Tested

- 144/144 upstream tests pass locally (`scripts/test`)
- `scripts/check` clean (ruff + pylint 10/10)
- `scripts/security-check` 0 vulnerabilities
- End-to-end against a Passport OIDC IdP on v1.0.2: fresh incognito → welcome → *alternative sign-in* → click OIDC picker row → redirected to welcome → IdP → callback → finish → dashboard. The HA Local row on the same picker is not hijacked (exact-match only), so local auth remains available for decoupling.

## Explicit trade-off

The picker row label is now the plugin's `DEFAULT_TITLE` ("OpenID Connect (SSO)") rather than the user-configured `display_name`. The welcome page button keeps the custom label. Most installs never land on the native picker anyway (v1.0.0+ auto-redirects root hits to welcome); the picker is a rare escape path where a generic label is acceptable.

## Not in scope

- Multi-OIDC-provider support
- Welcome-page branding beyond `display_name`
- Changes to `async_step_init`'s abort behavior (it's called from multiple entry points and still needs to abort on missing cookie for non-picker flows)
