### PR TITLE
Implement trusted_networks support

### DIFF
--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -90,24 +90,59 @@ async def async_unload_entry(_hass: HomeAssistant, _entry: ConfigEntry):
     return False
 
 
-async def _setup_oidc_provider(hass: HomeAssistant, my_config: dict, display_name: str):
-    """Set up the OIDC provider with the given configuration."""
-    providers = OrderedDict()
-
+async def _register_oidc_provider(hass: HomeAssistant, my_config: dict):
+    """Register the OIDC provider in Home Assistant's auth system."""
     # Use private APIs until there is a real auth platform
+
     # pylint: disable=protected-access
+    providers = OrderedDict()
     provider = OpenIDAuthProvider(hass, hass.auth._store, my_config)
 
+    existing_auth_providers = hass.auth._providers.copy()
+    _LOGGER.debug("Current auth providers: %s", list(existing_auth_providers.keys()))
+    has_other_auth_providers = len(existing_auth_providers) > 0
+    has_trusted_networks_provider_first = False
+
+    if has_other_auth_providers:
+        # Pop the first provider from the existing providers to check if it's trusted_networks
+        first_provider_key, first_provider_obj = next(
+            iter(existing_auth_providers.items())
+        )
+        existing_auth_providers.pop(first_provider_key)
+
+        if first_provider_key[0] == "trusted_networks":
+            _LOGGER.info(
+                "Trusted Networks provider detected as the first auth provider. "
+                + "Keeping registration order intact."
+            )
+            providers[first_provider_key] = first_provider_obj
+            has_trusted_networks_provider_first = True
+        else:
+            # Reset back to what we had before
+            existing_auth_providers = hass.auth._providers.copy()
+
+    # Register OIDC at the start of the array
+    # OIDC needs to be first because it needs to process the login cookie after sign-in
     providers[(provider.type, provider.id)] = provider
 
-    # Get current provider count
-    has_other_auth_providers = len(hass.auth._providers) > 0
+    # Add back any other providers that were already registered
+    providers.update(existing_auth_providers)
 
-    providers.update(hass.auth._providers)
+    _LOGGER.debug("Final auth providers: %s", list(providers.values()))
     hass.auth._providers = providers
     # pylint: enable=protected-access
 
     _LOGGER.info("Registered OIDC provider")
+    return provider, has_other_auth_providers, has_trusted_networks_provider_first
+
+
+async def _setup_oidc_provider(hass: HomeAssistant, my_config: dict, display_name: str):
+    """Set up the OIDC provider with the given configuration."""
+    (
+        provider,
+        has_other_auth_providers,
+        has_trusted_networks_provider_first,
+    ) = await _register_oidc_provider(hass, my_config)
 
     # Set the correct scopes
     # Always use 'openid' & 'profile' as they are specified in the OIDC spec
@@ -179,6 +214,8 @@ async def _setup_oidc_provider(hass: HomeAssistant, my_config: dict, display_nam
     _LOGGER.info("Registered OIDC views")
 
     # Inject OIDC code into the frontend for /auth/authorize for automatic redirect
-    await OIDCInjectedAuthPage.inject(hass, force_https)
+    await OIDCInjectedAuthPage.inject(
+        hass, provider, force_https, has_trusted_networks_provider_first
+    )
 
     return True

--- a/custom_components/auth_oidc/endpoints/injected_auth_page.py
+++ b/custom_components/auth_oidc/endpoints/injected_auth_page.py
@@ -11,6 +11,7 @@ from homeassistant.components.http import HomeAssistantView, StaticPathConfig
 from homeassistant.core import HomeAssistant
 
 from .welcome import PATH as WELCOME_PATH
+from ..provider import OpenIDAuthProvider
 from ..tools.helpers import get_url
 
 PATH = "/auth/authorize"
@@ -24,7 +25,12 @@ async def read_file(path: str) -> str:
         return await f.read()
 
 
-async def frontend_injection(hass: HomeAssistant, force_https: bool) -> None:
+async def frontend_injection(
+    hass: HomeAssistant,
+    provider: OpenIDAuthProvider,
+    force_https: bool,
+    has_trusted_networks_provider_first: bool,
+) -> None:
     """Inject new frontend code into /auth/authorize."""
     router = hass.http.app.router
     frontend_path = None
@@ -81,7 +87,11 @@ async def frontend_injection(hass: HomeAssistant, force_https: bool) -> None:
     )
 
     # If everything is succesful, register a fake view that just returns the modified HTML
-    hass.http.register_view(OIDCInjectedAuthPage(frontend_code, force_https))
+    hass.http.register_view(
+        OIDCInjectedAuthPage(
+            frontend_code, provider, force_https, has_trusted_networks_provider_first
+        )
+    )
     _LOGGER.info("Performed OIDC frontend injection")
 
 
@@ -92,21 +102,36 @@ class OIDCInjectedAuthPage(HomeAssistantView):
     url = PATH
     name = "auth:oidc:authorize_page"
 
-    def __init__(self, html: str, force_https: bool) -> None:
+    def __init__(
+        self,
+        html: str,
+        provider: OpenIDAuthProvider,
+        force_https: bool,
+        has_trusted_networks_provider_first: bool,
+    ) -> None:
         """Initialize the injected auth page."""
         self.html = html
+        self.provider = provider
         self.force_https = force_https
+        self.has_trusted_networks_provider_first = has_trusted_networks_provider_first
 
     @staticmethod
-    async def inject(hass: HomeAssistant, force_https: bool) -> None:
+    async def inject(
+        hass: HomeAssistant,
+        provider: OpenIDAuthProvider,
+        force_https: bool,
+        has_trusted_networks_provider_first: bool,
+    ) -> None:
         """Inject the OIDC auth page into the frontend."""
+
         try:
-            await frontend_injection(hass, force_https)
+            await frontend_injection(
+                hass, provider, force_https, has_trusted_networks_provider_first
+            )
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.error("Failed to inject OIDC auth page: %s", e)
 
-    @staticmethod
-    def _should_do_oidc_redirect(req: web.Request) -> bool:
+    def _should_do_oidc_redirect(self, req: web.Request) -> bool:
         """Check if we should redirect to the OIDC flow."""
         # Set when we return from finish
         if req.query.get("skip_oidc_redirect") == "true":
@@ -116,6 +141,13 @@ class OIDCInjectedAuthPage(HomeAssistantView):
         # for example when you click the "other" button on the welcome screen
         redirect_uri = req.query.get("redirect_uri")
         if not redirect_uri:
+            return False
+
+        # Check if we are on a trusted network if we have trusted networks registered first
+        if (
+            self.has_trusted_networks_provider_first
+            and self.provider.is_trusted_network_host()
+        ):
             return False
 
         # Handle both encoded and plain redirect_uri values.

--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -11,7 +11,7 @@ from ipaddress import (
     IPv4Address,
     IPv6Address,
 )
-from homeassistant.auth import EVENT_USER_ADDED
+from homeassistant.auth import EVENT_USER_ADDED, InvalidAuthError as HAInvalidAuthError
 from homeassistant.auth.providers import (
     AUTH_PROVIDERS,
     AuthProvider,
@@ -25,7 +25,6 @@ from homeassistant.auth.providers import (
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components import http, person
-from homeassistant.exceptions import HomeAssistantError
 
 from .config.const import (
     FEATURES,
@@ -45,7 +44,7 @@ HASS_PROVIDER_TYPE = "homeassistant"
 COOKIE_NAME = "auth_oidc_state"
 
 
-class InvalidAuthError(HomeAssistantError):
+class InvalidAuthError(HAInvalidAuthError):
     """Raised when submitting invalid authentication."""
 
 
@@ -142,7 +141,7 @@ class OpenIDAuthProvider(AuthProvider):
             trusted_network_provider.async_validate_access(ip_address(ip))
             _LOGGER.info("IP %s is in a trusted network, skipping OIDC flow", ip)
             return True
-        except InvalidAuthError:
+        except HAInvalidAuthError:
             # Log the error
             _LOGGER.info(
                 "IP %s is not in a trusted network, proceeding with OIDC flow", ip

--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -148,6 +148,13 @@ class OpenIDAuthProvider(AuthProvider):
                 "IP %s is not in a trusted network, proceeding with OIDC flow", ip
             )
             return False
+        # Catch every other error, HA might have changed the API.
+        # pylint: disable=broad-exception-caught
+        except Exception as e:
+            _LOGGER.warning(
+                "Error while validating trusted network for IP %s: %s", ip, e
+            )
+            return False
 
     async def async_create_state(self, redirect_uri: str, ip: str | None = None) -> str:
         """Create a new OIDC state and return the state id."""

--- a/custom_components/auth_oidc/provider.py
+++ b/custom_components/auth_oidc/provider.py
@@ -6,6 +6,11 @@ import logging
 
 from typing import Dict, Optional
 import asyncio
+from ipaddress import (
+    ip_address,
+    IPv4Address,
+    IPv6Address,
+)
 from homeassistant.auth import EVENT_USER_ADDED
 from homeassistant.auth.providers import (
     AUTH_PROVIDERS,
@@ -30,6 +35,8 @@ from .config.const import (
 )
 from .stores.state_store import StateStore
 from .tools.types import UserDetails
+
+type IPAddress = IPv4Address | IPv6Address
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,6 +120,34 @@ class OpenIDAuthProvider(AuthProvider):
             return req.remote
 
         return None
+
+    def is_trusted_network_host(self) -> bool:
+        """Check if the current request is coming from a trusted network host."""
+        ip = self._resolve_ip()
+        if ip is None:
+            return False
+
+        # Check if trusted networks auth provider is present
+        trusted_network_provider = self.hass.auth.get_auth_provider(
+            "trusted_networks", None
+        )
+        if not trusted_network_provider:
+            return False
+
+        _LOGGER.debug(
+            "Trusted networks present and checking if we should OIDC redirect"
+        )
+
+        try:
+            trusted_network_provider.async_validate_access(ip_address(ip))
+            _LOGGER.info("IP %s is in a trusted network, skipping OIDC flow", ip)
+            return True
+        except InvalidAuthError:
+            # Log the error
+            _LOGGER.info(
+                "IP %s is not in a trusted network, proceeding with OIDC flow", ip
+            )
+            return False
 
     async def async_create_state(self, redirect_uri: str, ip: str | None = None) -> str:
         """Create a new OIDC state and return the state id."""

--- a/tests/test_hass_auth_provider.py
+++ b/tests/test_hass_auth_provider.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 from unittest.mock import patch
 import pytest
 
+from homeassistant.auth import InvalidAuthError
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
@@ -22,7 +23,6 @@ from custom_components.auth_oidc.config.const import (
     FEATURES_AUTOMATIC_PERSON_CREATION,
     FEATURES_AUTOMATIC_USER_LINKING,
 )
-from custom_components.auth_oidc.provider import InvalidAuthError
 from .mocks.oidc_server import MockOIDCServer, mock_oidc_responses
 
 FAKE_REDIR_URL = "http://example.com/auth/authorize?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%3A8123%2F%3Fauth_callback%3D1&client_id=http%3A%2F%2Fexample.com%3A8123%2F&state=example"
@@ -130,7 +130,7 @@ async def test_provider_is_trusted_network_host_true_for_allowed_ip(
 
 @pytest.mark.asyncio
 async def test_provider_is_trusted_network_host_false_for_disallowed_ip(
-    hass: HomeAssistant,
+    hass: HomeAssistant, caplog
 ):
     """Provider should return False when trusted provider denies the current IP."""
     await setup(
@@ -159,6 +159,15 @@ async def test_provider_is_trusted_network_host_false_for_disallowed_ip(
     ) as current_request:
         current_request.get.return_value = SimpleNamespace(remote="127.0.0.1")
         assert provider.is_trusted_network_host() is False
+        assert any(
+            level >= 0
+            and "is not in a trusted network, proceeding with OIDC flow" in message
+            for _, level, message in caplog.record_tuples
+        )
+        assert not any(
+            level >= 0 and "Error while validating trusted network for IP" in message
+            for _, level, message in caplog.record_tuples
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_hass_auth_provider.py
+++ b/tests/test_hass_auth_provider.py
@@ -26,6 +26,10 @@ from custom_components.auth_oidc.provider import InvalidAuthError
 from .mocks.oidc_server import MockOIDCServer, mock_oidc_responses
 
 FAKE_REDIR_URL = "http://example.com/auth/authorize?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%3A8123%2F%3Fauth_callback%3D1&client_id=http%3A%2F%2Fexample.com%3A8123%2F&state=example"
+DEFAULT_CONFIG = {
+    CLIENT_ID: "dummy",
+    DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+}
 
 
 async def setup(hass: HomeAssistant, config: dict, expect_success: bool) -> bool:
@@ -42,10 +46,7 @@ async def test_setup_success_auth_provider_registration(hass: HomeAssistant):
     """Test successful setup"""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -64,10 +65,7 @@ async def test_provider_ip_fallback_fails_closed_without_request_context(
     """Provider should not invent a shared IP when request context is missing."""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -85,10 +83,7 @@ async def test_provider_cookie_header_sets_secure_when_requested(hass: HomeAssis
     """Cookie header should include Secure when HTTPS is in use."""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -107,10 +102,7 @@ async def test_provider_is_trusted_network_host_true_for_allowed_ip(
     """Provider should detect trusted network host when trusted provider allows the IP."""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -143,10 +135,7 @@ async def test_provider_is_trusted_network_host_false_for_disallowed_ip(
     """Provider should return False when trusted provider denies the current IP."""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -179,10 +168,7 @@ async def test_provider_is_trusted_network_host_false_without_trusted_provider(
     """Provider should return False when trusted_networks auth provider is absent."""
     await setup(
         hass,
-        {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
-        },
+        DEFAULT_CONFIG,
         True,
     )
 
@@ -268,8 +254,7 @@ async def test_full_login(hass: HomeAssistant, hass_client):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: False,
@@ -299,8 +284,7 @@ async def test_login_with_linking(hass: HomeAssistant, hass_client):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: True,
@@ -334,8 +318,7 @@ async def test_login_with_person_create(hass: HomeAssistant, hass_client):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: True,
                 FEATURES_AUTOMATIC_USER_LINKING: False,
@@ -368,8 +351,7 @@ async def test_login_without_person_create_does_not_create_person(
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: False,
@@ -396,8 +378,7 @@ async def test_login_shows_form(hass: HomeAssistant):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: False,
@@ -420,8 +401,7 @@ async def test_login_with_invalid_cookie_aborts(hass: HomeAssistant):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: False,
@@ -453,8 +433,7 @@ async def test_login_with_no_cookie_aborts(hass: HomeAssistant):
     await setup(
         hass,
         {
-            CLIENT_ID: "dummy",
-            DISCOVERY_URL: MockOIDCServer.get_discovery_url(),
+            **DEFAULT_CONFIG,
             FEATURES: {
                 FEATURES_AUTOMATIC_PERSON_CREATION: False,
                 FEATURES_AUTOMATIC_USER_LINKING: False,

--- a/tests/test_hass_auth_provider.py
+++ b/tests/test_hass_auth_provider.py
@@ -2,6 +2,7 @@
 
 import base64
 import re
+from collections import OrderedDict
 from types import SimpleNamespace
 from urllib.parse import parse_qs, unquote, urlparse
 from unittest.mock import patch
@@ -21,6 +22,7 @@ from custom_components.auth_oidc.config.const import (
     FEATURES_AUTOMATIC_PERSON_CREATION,
     FEATURES_AUTOMATIC_USER_LINKING,
 )
+from custom_components.auth_oidc.provider import InvalidAuthError
 from .mocks.oidc_server import MockOIDCServer, mock_oidc_responses
 
 FAKE_REDIR_URL = "http://example.com/auth/authorize?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%3A8123%2F%3Fauth_callback%3D1&client_id=http%3A%2F%2Fexample.com%3A8123%2F&state=example"
@@ -96,6 +98,105 @@ async def test_provider_cookie_header_sets_secure_when_requested(hass: HomeAssis
     assert "SameSite=Lax" in cookie_header
     assert "HttpOnly" in cookie_header
     assert "Secure" in cookie_header
+
+
+@pytest.mark.asyncio
+async def test_provider_is_trusted_network_host_true_for_allowed_ip(
+    hass: HomeAssistant,
+):
+    """Provider should detect trusted network host when trusted provider allows the IP."""
+    await setup(
+        hass,
+        {
+            CLIENT_ID: "dummy",
+            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
+        },
+        True,
+    )
+
+    provider = hass.auth.get_auth_providers(DOMAIN)[0]
+
+    class TrustedNetworksAllowProvider:
+        def async_validate_access(self, _ip_addr):
+            return None
+
+    # pylint: disable=protected-access
+    hass.auth._providers = OrderedDict(
+        [
+            (("trusted_networks", None), TrustedNetworksAllowProvider()),
+            ((provider.type, provider.id), provider),
+        ]
+    )
+    # pylint: enable=protected-access
+
+    with patch(
+        "custom_components.auth_oidc.provider.http.current_request"
+    ) as current_request:
+        current_request.get.return_value = SimpleNamespace(remote="127.0.0.1")
+        assert provider.is_trusted_network_host() is True
+
+
+@pytest.mark.asyncio
+async def test_provider_is_trusted_network_host_false_for_disallowed_ip(
+    hass: HomeAssistant,
+):
+    """Provider should return False when trusted provider denies the current IP."""
+    await setup(
+        hass,
+        {
+            CLIENT_ID: "dummy",
+            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
+        },
+        True,
+    )
+
+    provider = hass.auth.get_auth_providers(DOMAIN)[0]
+
+    class TrustedNetworksDenyProvider:
+        def async_validate_access(self, _ip_addr):
+            raise InvalidAuthError("Not in trusted_networks")
+
+    # pylint: disable=protected-access
+    hass.auth._providers = OrderedDict(
+        [
+            (("trusted_networks", None), TrustedNetworksDenyProvider()),
+            ((provider.type, provider.id), provider),
+        ]
+    )
+    # pylint: enable=protected-access
+
+    with patch(
+        "custom_components.auth_oidc.provider.http.current_request"
+    ) as current_request:
+        current_request.get.return_value = SimpleNamespace(remote="127.0.0.1")
+        assert provider.is_trusted_network_host() is False
+
+
+@pytest.mark.asyncio
+async def test_provider_is_trusted_network_host_false_without_trusted_provider(
+    hass: HomeAssistant,
+):
+    """Provider should return False when trusted_networks auth provider is absent."""
+    await setup(
+        hass,
+        {
+            CLIENT_ID: "dummy",
+            DISCOVERY_URL: "https://example.com/.well-known/openid-configuration",
+        },
+        True,
+    )
+
+    provider = hass.auth.get_auth_providers(DOMAIN)[0]
+
+    # Without actually getting the IP, should also be false
+    assert provider.is_trusted_network_host() is False
+
+    # With the IP, should be false
+    with patch(
+        "custom_components.auth_oidc.provider.http.current_request"
+    ) as current_request:
+        current_request.get.return_value = SimpleNamespace(remote="127.0.0.1")
+        assert provider.is_trusted_network_host() is False
 
 
 async def login_user(hass: HomeAssistant, state_id: str):

--- a/tests/test_hass_oidc_client_integration.py
+++ b/tests/test_hass_oidc_client_integration.py
@@ -3,14 +3,17 @@
 import base64
 import asyncio
 import re
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, unquote, urlparse, urlencode
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.auth_oidc import DOMAIN
+from custom_components.auth_oidc.provider import COOKIE_NAME
 from custom_components.auth_oidc.tools.oidc_client import (
     OIDCDiscoveryClient,
     OIDCDiscoveryInvalid,
@@ -246,6 +249,47 @@ async def test_full_oidc_flow(hass: HomeAssistant, hass_client):
 
         # POST to finish without any POST body should result in 302 back to the original redirect_uri
         await verify_back_redirect(client, redirect_uri)
+
+
+@pytest.mark.asyncio
+async def test_login_flow_init_completes_with_state_cookie(
+    hass: HomeAssistant, hass_client
+):
+    """The provider login flow init step should finalize when the auth cookie is present."""
+    await setup(hass)
+
+    with mock_oidc_responses():
+        client = await hass_client()
+        redirect_uri = create_redirect_uri(WEB_CLIENT_ID)
+
+        state, _, status = await get_welcome_for_client(client, redirect_uri)
+        assert status == 200
+
+        authorization_url = await get_redirect_auth_url(client)
+        session = async_get_clientsession(hass)
+        resp_auth = session.get(authorization_url, allow_redirects=False)
+        json_auth = await resp_auth.json()
+
+        resp = await client.get(
+            f"/auth/oidc/callback?code={json_auth['code']}&state={state}",
+            allow_redirects=False,
+        )
+        assert resp.status == 302
+
+        provider = hass.auth.get_auth_providers(DOMAIN)[0]
+        flow = await provider.async_login_flow({})
+
+        fake_request = SimpleNamespace(
+            cookies={COOKIE_NAME: state},
+            remote="127.0.0.1",
+        )
+        with patch(
+            "custom_components.auth_oidc.provider.http.current_request"
+        ) as current_request:
+            current_request.get.return_value = fake_request
+            result = await flow.async_step_init({})
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 async def discovery_test_through_redirect(

--- a/tests/test_hass_webserver.py
+++ b/tests/test_hass_webserver.py
@@ -2,6 +2,7 @@
 
 import base64
 import os
+from collections import OrderedDict
 from urllib.parse import parse_qs, quote, unquote, urlparse, urlencode
 from unittest.mock import AsyncMock, MagicMock, patch
 from auth_oidc.config.const import (
@@ -25,6 +26,22 @@ from custom_components.auth_oidc.endpoints.injected_auth_page import (
 )
 
 MOBILE_CLIENT_ID = "https://home-assistant.io/Android"
+WELCOME_PATH = "/auth/oidc/welcome"
+INJECTION_SCRIPT_MARKER = "<script src='/auth/oidc/static/injection.js"
+
+
+def assert_redirects_to_welcome(resp) -> None:
+    """Assert a response redirects to the OIDC welcome endpoint."""
+    assert resp.status == 302
+    location = resp.headers["Location"]
+    parsed_location = urlparse(location)
+    assert parsed_location.path == WELCOME_PATH
+
+
+async def assert_normal_login_screen(resp) -> None:
+    """Assert we stayed on the auth page and render the injected normal login HTML."""
+    assert resp.status == 200
+    assert INJECTION_SCRIPT_MARKER in await resp.text()
 
 
 def create_redirect_uri(client_id: str) -> str:
@@ -310,7 +327,9 @@ async def test_welcome_desktop_auto_redirects_without_other_providers(
     """Welcome should auto-redirect desktop clients when no other providers exist."""
 
     # pylint: disable=protected-access
-    hass.auth._providers = []  # Clear initial providers out
+    hass.auth._providers = {}  # Clear initial providers out
+    # pylint: enable=protected-access
+
     await setup(hass)
 
     client = await hass_client()
@@ -334,7 +353,7 @@ async def test_redirect_without_cookie_goes_to_welcome(
     client = await hass_client()
     resp = await client.get("/auth/oidc/redirect", allow_redirects=False)
     assert resp.status == 302
-    assert "/auth/oidc/welcome" in resp.headers["Location"]
+    assert_redirects_to_welcome(resp)
 
 
 @pytest.mark.asyncio
@@ -730,10 +749,7 @@ async def test_frontend_injection(
 
     client = await hass_client()
     resp = await client.get("/auth/authorize", allow_redirects=False)
-    assert resp.status == 200  # 200 because there is no redirect_uri
-    text = await resp.text()
-
-    assert "<script src='/auth/oidc/static/injection.js" in text
+    await assert_normal_login_screen(resp)
 
 
 @pytest.mark.asyncio
@@ -760,8 +776,12 @@ async def test_frontend_injection_logs_and_returns_when_route_handler_is_unexpec
         def __iter__(self):
             return iter([FakeRoute()])
 
+    provider = MagicMock()
+
     with patch.object(hass.http.app.router, "resources", return_value=[FakeResource()]):
-        await frontend_injection(hass, force_https=False)
+        await frontend_injection(
+            hass, provider, force_https=False, has_trusted_networks_provider_first=False
+        )
 
     assert "Unexpected route handler type" in caplog.text
     assert (
@@ -780,7 +800,10 @@ async def test_injected_auth_page_inject_logs_errors(hass: HomeAssistant, caplog
         "custom_components.auth_oidc.endpoints.injected_auth_page.frontend_injection",
         side_effect=RuntimeError("boom"),
     ):
-        await OIDCInjectedAuthPage.inject(hass, force_https=False)
+        provider = MagicMock()
+        await OIDCInjectedAuthPage.inject(
+            hass, provider, force_https=False, has_trusted_networks_provider_first=False
+        )
 
     assert "Failed to inject OIDC auth page: boom" in caplog.text
 
@@ -836,5 +859,71 @@ async def test_injected_auth_page_returns_original_html_when_skipped(
     client = await hass_client()
     response = await client.get(request_target, allow_redirects=False)
 
-    assert response.status == 200
-    assert "<script src='/auth/oidc/static/injection.js" in await response.text()
+    await assert_normal_login_screen(response)
+
+
+@pytest.mark.asyncio
+async def test_injected_auth_page_trusted_networks_bypass_skips_oidc_redirect(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+):
+    """Trusted network hosts should bypass OIDC redirect when trusted_networks is first."""
+
+    class TrustedNetworksAllowProvider:
+        def async_validate_access(self, _ip_addr):
+            return None
+
+    # pylint: disable=protected-access
+    hass.auth._providers = OrderedDict(
+        [(("trusted_networks", None), TrustedNetworksAllowProvider())]
+    )
+    # pylint: enable=protected-access
+
+    await setup_mock_authorize_route(hass)
+    await setup(hass)
+
+    client = await hass_client()
+    encoded_redirect_uri = quote(create_redirect_uri(client.make_url("/")), safe="")
+
+    resp = await client.get(
+        f"/auth/authorize?redirect_uri={encoded_redirect_uri}",
+        allow_redirects=False,
+    )
+
+    await assert_normal_login_screen(resp)
+
+
+@pytest.mark.asyncio
+async def test_injected_auth_page_ignores_trusted_networks_when_not_first(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+):
+    """OIDC redirect should continue when trusted_networks is not the first provider."""
+
+    class DummyProvider:
+        pass
+
+    class TrustedNetworksAllowProvider:
+        def async_validate_access(self, _ip_addr):
+            return None
+
+    # Keep trusted_networks present but not first, so bypass should not apply.
+    # pylint: disable=protected-access
+    hass.auth._providers = OrderedDict(
+        [
+            (("homeassistant", None), DummyProvider()),
+            (("trusted_networks", None), TrustedNetworksAllowProvider()),
+        ]
+    )
+    # pylint: enable=protected-access
+
+    await setup_mock_authorize_route(hass)
+    await setup(hass)
+
+    client = await hass_client()
+    encoded_redirect_uri = quote(create_redirect_uri(client.make_url("/")), safe="")
+
+    resp = await client.get(
+        f"/auth/authorize?redirect_uri={encoded_redirect_uri}",
+        allow_redirects=False,
+    )
+
+    assert_redirects_to_welcome(resp)


### PR DESCRIPTION
With this PR you will now be able to configure [`trusted_networks` auth provider](https://www.home-assistant.io/docs/authentication/providers/#trusted-networks) to work alongside OIDC.

You can either:

1. Register `trusted_networks` first (or as the only auth provider besides OIDC).
   - If your device is from a trusted network, OIDC will be disabled and you will only see the trusted networks login page (or automatic login if you have enabled `allow_bypass_login`)
   - If your device is not from a trusted network there won't be any mention of that provider at all.
2. Register `trusted_networks` as the second auth provider (after `homeassistant`)
   - OIDC login will always start anyway, but you can manually go to trusted_networks by clicking on the "Use alternative sign-in method" link. You will then see 2 options: Home Assistant and Trusted Networks.
   - If your device is not from a trusted network, you will only see "Home Assistant" as an option on that screen.
   
---

Example config for option 1:

```
auth_oidc:
  discovery_url: ""
  client_id: ""

homeassistant:
  auth_providers:
    - type: trusted_networks
      trusted_networks:
        - 192.168.0.0/24
        - fd00::/8
```

with this config devices on 192.168.0.0/24 and fd00::/8 will not be able to use OIDC but will only be shown the Trusted Networks screen instead.

If you also configure `allow_bypass_login`, no login screen will be shown at all, such as with this config:

```
auth_oidc:
  discovery_url: ""
  client_id: ""

homeassistant:
  auth_providers:
    - type: trusted_networks
      trusted_networks:
        - 192.168.0.0/24
      trusted_users:
        "192.168.0.0/24": "user_id"
      allow_bypass_login: true
```

---

Example config for option 2:


```
auth_oidc:
  discovery_url: ""
  client_id: ""

homeassistant:
  auth_providers:
    - type: homeassistant
    - type: trusted_networks
      trusted_networks:
        - 192.168.0.0/24
        - fd00::/8
```

with this config devices on 192.168.0.0/24 and fd00::/8 will initially be redirected to the OIDC welcome page, but they are able to go to the "Use alternative sign-in method" screen to login with Trusted Networks instead.

---

Fixes #282 
Thank you @TheDuffman85 for originally suggesting this in https://github.com/christiaangoossens/hass-oidc-auth/discussions/30.