### PR TITLE
Use HTTP proxy for connecting to auth server if configured via env

### DIFF
--- a/custom_components/auth_oidc/tools/oidc_client.py
+++ b/custom_components/auth_oidc/tools/oidc_client.py
@@ -372,6 +372,7 @@ class OIDCClient:
             tcp_connector_args["ssl"] = ssl_context
 
         self.http_session = aiohttp.ClientSession(
+            trust_env=True,
             connector=aiohttp.TCPConnector(**tcp_connector_args)
         )
         return self.http_session


### PR DESCRIPTION
Without this, using an http proxy defined by the user is not possible without patching. See [aiohttp docs][1] for details.

[1]: https://docs.aiohttp.org/en/stable/client_advanced.html#aiohttp-client-proxy-support