### PR TITLE
Fix UX issues with external OAuth2 apps

### DIFF
--- a/custom_components/auth_oidc/endpoints/finish.py
+++ b/custom_components/auth_oidc/endpoints/finish.py
@@ -7,6 +7,7 @@ from ..tools.helpers import (
     error_response,
     get_valid_state_id,
     template_response,
+    concat_url_query
 )
 
 PATH = "/auth/oidc/finish"
@@ -56,13 +57,8 @@ class OIDCFinishView(HomeAssistantView):
 
         # We are trying sign-in on this browser
         if not device_code:
-            # Add to the URL correctly (also handle case where it's just the root)
-            separator = "?"
-            if "?" in redirect_uri:
-                separator = "&"
-
             # Redirect to this new URL for login, make sure to skip OIDC to prevent loops
-            redirect_uri = f"{redirect_uri}{separator}skip_oidc_redirect=true"
+            redirect_uri = concat_url_query(redirect_uri, "skip_oidc_redirect=true")
             raise web.HTTPFound(location=redirect_uri)
 
         # Check if we can link this device

--- a/custom_components/auth_oidc/endpoints/finish.py
+++ b/custom_components/auth_oidc/endpoints/finish.py
@@ -7,7 +7,7 @@ from ..tools.helpers import (
     error_response,
     get_valid_state_id,
     template_response,
-    concat_url_query
+    concat_url_query,
 )
 
 PATH = "/auth/oidc/finish"

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -31,9 +31,9 @@ class OIDCWelcomeView(HomeAssistantView):
     async def _process_url(self, redirect_uri: str) -> tuple[str, bool]:
         """Processes the redirect URI to determine if we need setTokens and if this is mobile."""
         # decodeURIComponent(btoa(...)) -> unquote first, then base64 decode
-        decoded_redirect_uri = base64.b64decode(unquote(redirect_uri), validate=True).decode(
-            "utf-8"
-        )
+        decoded_redirect_uri = base64.b64decode(
+            unquote(redirect_uri), validate=True
+        ).decode("utf-8")
 
         oauth2_url = urlparse(decoded_redirect_uri)
         oauth2_query = parse_qs(oauth2_url.query)
@@ -54,7 +54,9 @@ class OIDCWelcomeView(HomeAssistantView):
 
         if is_web_client:
             # Adjust the original_redirect_uri to include the storeTokens parameter
-            original_redirect_uri = concat_url_query(original_redirect_uri, "storeToken=true")
+            original_redirect_uri = concat_url_query(
+                original_redirect_uri, "storeToken=true"
+            )
             oauth2_query.update({"redirect_uri": original_redirect_uri})
 
             # Create new redirect_uri with the updated query parameters
@@ -81,7 +83,9 @@ class OIDCWelcomeView(HomeAssistantView):
         # and determine if this is a mobile client.
         if redirect_uri:
             try:
-                other_return_url, redirect_uri, is_mobile = await self._process_url(redirect_uri)
+                other_return_url, redirect_uri, is_mobile = await self._process_url(
+                    redirect_uri
+                )
             except (
                 binascii.Error,
                 UnicodeDecodeError,

--- a/custom_components/auth_oidc/endpoints/welcome.py
+++ b/custom_components/auth_oidc/endpoints/welcome.py
@@ -5,7 +5,7 @@ import binascii
 from urllib.parse import urlparse, parse_qs, unquote, urlencode
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
-from ..tools.helpers import error_response, get_url, template_response
+from ..tools.helpers import error_response, get_url, template_response, concat_url_query
 from ..provider import OpenIDAuthProvider
 from ..tools.types import OIDCWelcomeOptions
 
@@ -31,11 +31,11 @@ class OIDCWelcomeView(HomeAssistantView):
     async def _process_url(self, redirect_uri: str) -> tuple[str, bool]:
         """Processes the redirect URI to determine if we need setTokens and if this is mobile."""
         # decodeURIComponent(btoa(...)) -> unquote first, then base64 decode
-        redirect_uri = base64.b64decode(unquote(redirect_uri), validate=True).decode(
+        decoded_redirect_uri = base64.b64decode(unquote(redirect_uri), validate=True).decode(
             "utf-8"
         )
 
-        oauth2_url = urlparse(redirect_uri)
+        oauth2_url = urlparse(decoded_redirect_uri)
         oauth2_query = parse_qs(oauth2_url.query)
         client_id = oauth2_query.get("client_id")[0]
         original_redirect_uri = oauth2_query.get("redirect_uri")[0]
@@ -54,20 +54,19 @@ class OIDCWelcomeView(HomeAssistantView):
 
         if is_web_client:
             # Adjust the original_redirect_uri to include the storeTokens parameter
-            separator = "?"
-            if "?" in original_redirect_uri:
-                separator = "&"
-
-            original_redirect_uri = f"{original_redirect_uri}{separator}storeToken=true"
+            original_redirect_uri = concat_url_query(original_redirect_uri, "storeToken=true")
             oauth2_query.update({"redirect_uri": original_redirect_uri})
 
             # Create new redirect_uri with the updated query parameters
             new_oauth2_url = oauth2_url._replace(
                 query=urlencode(oauth2_query, doseq=True)
             )
-            redirect_uri = new_oauth2_url.geturl()
+            state_redirect_uri = new_oauth2_url.geturl()
+        else:
+            state_redirect_uri = decoded_redirect_uri
 
-        return redirect_uri, is_mobile
+        # Make sure to also return the original decoded URL for other_return_url
+        return decoded_redirect_uri, state_redirect_uri, is_mobile
 
     async def get(self, req: web.Request) -> web.Response:
         """Receive response."""
@@ -75,11 +74,14 @@ class OIDCWelcomeView(HomeAssistantView):
         # Get the query parameter with the redirect_uri
         redirect_uri = req.query.get("redirect_uri")
 
+        # Failsafe the other return to / in case of mobile or direct open of the welcome page
+        other_return_url = get_url("/", self.force_https)
+
         # Do some processing on the redirect_uri to correct it
         # and determine if this is a mobile client.
         if redirect_uri:
             try:
-                redirect_uri, is_mobile = await self._process_url(redirect_uri)
+                other_return_url, redirect_uri, is_mobile = await self._process_url(redirect_uri)
             except (
                 binascii.Error,
                 UnicodeDecodeError,
@@ -128,7 +130,7 @@ class OIDCWelcomeView(HomeAssistantView):
         # And add the other link if we have other auth providers
         other_link = None
         if self.has_other_auth_providers:
-            other_link = get_url("/?skip_oidc_redirect=true", self.force_https)
+            other_link = concat_url_query(other_return_url, "skip_oidc_redirect=true")
 
         # And display
         response = await template_response(

--- a/custom_components/auth_oidc/static/injection.js
+++ b/custom_components/auth_oidc/static/injection.js
@@ -16,19 +16,25 @@ function interceptPickerRow(authProviderElement) {
     console.warn("[OIDC] ha-pick-auth-provider has no shadowRoot; HA frontend may have changed.")
     return
   }
+
   const items = authProviderElement.shadowRoot.querySelectorAll('ha-list-item')
   if (items.length === 0) return  // not yet populated; retry on next mutation
+
   for (const item of items) {
     if ((item.innerText || '').trim() !== OIDC_PROVIDER_NAME) continue
-    item.addEventListener('click', (e) => {
-      e.stopImmediatePropagation()
-      e.preventDefault()
-      window.location.href =
-        OIDC_WELCOME_PATH +
-        '?redirect_uri=' + encodeURIComponent(btoa(window.location.href))
-    }, true)
+
+    // We should hide it entirely as making it clickable
+    // causes so many weird loop issues
+    item.style.display = "none"
     pickerIntercepted = true
-    return
+
+    break
+  }
+
+  // If we have found it and we are the only provider,
+  // hide the entire picker for better UX
+  if (pickerIntercepted && items.length == 1) {
+    authProviderElement.style.display = "none"
   }
 }
 
@@ -38,17 +44,18 @@ function update() {
 
   const authProviderElement = document.querySelector('ha-pick-auth-provider')
 
-  // Intercept picker clicks so the OIDC cookie is set before submit.
   interceptPickerRow(authProviderElement)
 
   // Auto-select on "Login aborted".
   if (!authFlowElement.innerText.includes('Login aborted')) return
   if (!authProviderElement) return
   const firstListItem = authProviderElement.shadowRoot?.querySelector('ha-list-item')
+  
   if (!firstListItem) {
     console.warn("[OIDC] No ha-list-item found inside ha-pick-auth-provider. Not automatically selecting OIDC provider.")
     return
   }
+  
   firstListItem.click()
 }
 

--- a/custom_components/auth_oidc/tools/helpers.py
+++ b/custom_components/auth_oidc/tools/helpers.py
@@ -37,6 +37,10 @@ def get_state_id(request: web.Request) -> str | None:
     """Return the current OIDC state cookie, if present."""
     return request.cookies.get(STATE_COOKIE_NAME)
 
+def reset_state_cookie() -> str:
+    """Return a Set-Cookie header value to reset the state cookie."""
+    return f"{STATE_COOKIE_NAME}=; Path=/auth/; SameSite=Lax; HttpOnly; Max-Age=0"
+
 
 async def get_valid_state_id(
     request: web.Request, oidc_provider: "OpenIDAuthProvider"
@@ -52,9 +56,9 @@ async def get_valid_state_id(
     return state_id
 
 
-def html_response(html: str, status: int = 200) -> web.Response:
+def html_response(html: str, status: int = 200, headers=None) -> web.Response:
     """Return an HTML response with the standard content type."""
-    return web.Response(text=html, content_type="text/html", status=status)
+    return web.Response(text=html, content_type="text/html", status=status, headers=headers)
 
 
 async def template_response(
@@ -66,4 +70,13 @@ async def template_response(
 
 async def error_response(message: str, status: int = 400) -> web.Response:
     """Render the shared error view."""
-    return html_response(await get_view("error", {"error": message}), status=status)
+    return html_response(await get_view("error", {"error": message}), status=status, headers={
+        "set-cookie": reset_state_cookie(),
+    })
+
+def concat_url_query(base: str, new_query: str) -> str:
+    """Concatenate a base URL with a new query string, handling existing queries."""
+    separator = "?"
+    if "?" in base:
+        separator = "&"
+    return f"{base}{separator}{new_query}"

--- a/custom_components/auth_oidc/tools/helpers.py
+++ b/custom_components/auth_oidc/tools/helpers.py
@@ -37,6 +37,7 @@ def get_state_id(request: web.Request) -> str | None:
     """Return the current OIDC state cookie, if present."""
     return request.cookies.get(STATE_COOKIE_NAME)
 
+
 def reset_state_cookie() -> str:
     """Return a Set-Cookie header value to reset the state cookie."""
     return f"{STATE_COOKIE_NAME}=; Path=/auth/; SameSite=Lax; HttpOnly; Max-Age=0"
@@ -58,7 +59,9 @@ async def get_valid_state_id(
 
 def html_response(html: str, status: int = 200, headers=None) -> web.Response:
     """Return an HTML response with the standard content type."""
-    return web.Response(text=html, content_type="text/html", status=status, headers=headers)
+    return web.Response(
+        text=html, content_type="text/html", status=status, headers=headers
+    )
 
 
 async def template_response(
@@ -70,9 +73,14 @@ async def template_response(
 
 async def error_response(message: str, status: int = 400) -> web.Response:
     """Render the shared error view."""
-    return html_response(await get_view("error", {"error": message}), status=status, headers={
-        "set-cookie": reset_state_cookie(),
-    })
+    return html_response(
+        await get_view("error", {"error": message}),
+        status=status,
+        headers={
+            "set-cookie": reset_state_cookie(),
+        },
+    )
+
 
 def concat_url_query(base: str, new_query: str) -> str:
     """Concatenate a base URL with a new query string, handling existing queries."""

--- a/custom_components/auth_oidc/views/templates/welcome.html
+++ b/custom_components/auth_oidc/views/templates/welcome.html
@@ -5,13 +5,6 @@
 {% endblock %}
 {% block content %}
 <div class="text-center">
-    <div id="signed-in" class="bg-blue-100 border border-blue-400 text-blue-700 px-4 py-3 rounded relative mb-8 hidden"
-        role="alert">
-        <p>You seem to be logged in already.</p>
-        <p><a href="/" class="text-blue-600 hover:underline hover:text-blue-700 font-bold">Open the Home Assistant
-                dashboard</a></p>
-    </div>
-
     {% if code %}
         <div>
             <p id="device-instructions">Please login to Home Assistant on another device and enter this code when asked:</p>
@@ -54,14 +47,8 @@
 
     {% if other_link %}
         <p class=" mt-4 text-sm text-center">
-            <a id="alternative-sign-in-link" href="{{ other_link }}" class="text-gray-600 hover:underline">Use alternative sign-in method</a>
+            <a id="alternative-sign-in-link" href="{{ other_link }}" class="text-gray-600 hover:underline">Continue with default login</a>
         </p>
     {% endif %}
 </div>
-<script>
-    // Show the direct login button if we already have a token
-    if (localStorage.getItem('hassTokens')) {
-        document.getElementById('signed-in').classList.remove('hidden');
-    }
-</script>
 {% endblock %}

--- a/tests/test_hass_webserver.py
+++ b/tests/test_hass_webserver.py
@@ -428,10 +428,33 @@ async def test_callback_registration(
 
 
 @pytest.mark.asyncio
-async def test_callback_rejects_missing_code_or_state(
+async def test_callback_rejects_missing_state(
     hass: HomeAssistant, hass_client: ClientSessionGenerator
 ):
-    """Callback must reject requests missing either code or state."""
+    """Callback must reject requests missing state."""
+    await setup(hass)
+
+    client = await hass_client()
+    redirect_uri = create_redirect_uri(client.make_url("/"))
+    encoded = encode_redirect_uri(redirect_uri)
+    await client.get(
+        f"/auth/oidc/welcome?redirect_uri={encoded}",
+        allow_redirects=False,
+    )
+
+    resp_missing_state = await client.get(
+        "/auth/oidc/callback?code=testcode",
+        allow_redirects=False,
+    )
+    assert resp_missing_state.status == 400
+    assert "Missing code or state parameter." in await resp_missing_state.text()
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_missing_code(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+):
+    """Callback must reject requests missing code."""
     await setup(hass)
 
     client = await hass_client()
@@ -449,14 +472,6 @@ async def test_callback_rejects_missing_code_or_state(
     )
     assert resp_missing_code.status == 400
     assert "Missing code or state parameter." in await resp_missing_code.text()
-
-    resp_missing_state = await client.get(
-        "/auth/oidc/callback?code=testcode",
-        allow_redirects=False,
-    )
-    assert resp_missing_state.status == 400
-    assert "Missing code or state parameter." in await resp_missing_state.text()
-
 
 @pytest.mark.asyncio
 async def test_callback_rejects_state_mismatch(


### PR DESCRIPTION
Fixes #318 

Removes:

- The redundant blue box with 'You seem to be logged in already' as you now start at the root URL which will never trigger OIDC anyway if logged in
- Back link from the 'alternative sign-in screen' as it was buggy and sometimes triggered on its own causing loops

Fixes:

- Other URL/continue with default login now actually uses the redirect_uri, making sure that you are returned exactly where you would have been before without OIDC (#338)