### PR TITLE
ui: align login look and feel with Home Assistant authorize page (Tailwind)

### DIFF
--- a/custom_components/auth_oidc/__init__.py
+++ b/custom_components/auth_oidc/__init__.py
@@ -193,6 +193,11 @@ async def _setup_oidc_provider(hass: HomeAssistant, my_config: dict, display_nam
                 hass.config.path("custom_components/auth_oidc/static/style.css"),
                 cache_headers=True,
             ),
+            StaticPathConfig(
+                "/auth/oidc/static/icon.png",
+                hass.config.path("custom_components/auth_oidc/brand/icon.png"),
+                cache_headers=True,
+            ),
         ]
     )
 

--- a/custom_components/auth_oidc/static/input.css
+++ b/custom_components/auth_oidc/static/input.css
@@ -1,3 +1,92 @@
 @import "tailwindcss";
 
 @source "../views/templates";
+
+@font-face {
+  font-family: "Roboto";
+  src: local("Roboto Regular"), local("Roboto-Regular"),
+    url("/static/fonts/roboto/Roboto-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Roboto";
+  src: local("Roboto Medium"), local("Roboto-Medium"),
+    url("/static/fonts/roboto/Roboto-Medium.woff2") format("woff2");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Roboto";
+  src: local("Roboto Bold"), local("Roboto-Bold"),
+    url("/static/fonts/roboto/Roboto-Bold.woff2") format("woff2");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  color-scheme: light dark;
+  --primary-background-color: #fafafa;
+  --card-background-color: #ffffff;
+  --primary-text-color: #141414;
+  --secondary-text-color: #5e5e5e;
+  --primary-color: #009ac7;
+  --ha-color-primary-30: #006787;
+  --divider-color: rgba(0, 0, 0, 0.12);
+  --ha-color-form-background: #f3f3f3;
+  --ha-color-form-background-hover: #e6e6e6;
+  --ha-color-border-neutral-loud: #5e5e5e;
+  --ha-color-focus: #989898;
+  --error-color: #db4437;
+  --warning-color: #ffa600;
+  --success-color: #43a047;
+  --info-color: #039be5;
+  --ha-line-height-normal: 1.6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary-background-color: #111111;
+    --card-background-color: #1c1c1c;
+    --primary-text-color: #e1e1e1;
+    --secondary-text-color: #9b9b9b;
+    --divider-color: rgba(225, 225, 225, 0.12);
+    --ha-color-form-background: #363636;
+    --ha-color-form-background-hover: #4a4a4a;
+    --ha-color-border-neutral-loud: #b1b1b1;
+  }
+}
+
+@theme {
+  --font-sans: "Roboto", "Noto", sans-serif, ui-sans-serif, system-ui;
+}
+
+@layer base {
+  body {
+    font-size: 14px;
+    line-height: var(--ha-line-height-normal);
+  }
+}
+
+@theme inline {
+  --color-background: var(--primary-background-color);
+  --color-card: var(--card-background-color);
+  --color-foreground: var(--primary-text-color);
+  --color-muted: var(--secondary-text-color);
+  --color-primary: var(--primary-color);
+  --color-primary-hover: var(--ha-color-primary-30);
+  --color-divider: var(--divider-color);
+  --color-input: var(--ha-color-form-background);
+  --color-input-hover: var(--ha-color-form-background-hover);
+  --color-input-border: var(--ha-color-border-neutral-loud);
+  --color-focus: var(--ha-color-focus);
+  --color-error: var(--error-color);
+  --color-warning: var(--warning-color);
+  --color-success: var(--success-color);
+  --color-info: var(--info-color);
+}

--- a/custom_components/auth_oidc/tools/helpers.py
+++ b/custom_components/auth_oidc/tools/helpers.py
@@ -6,6 +6,7 @@ from homeassistant.components import http
 from aiohttp import web
 
 from ..views.loader import AsyncTemplateRenderer
+from ..config.const import REPO_ROOT_URL
 
 if TYPE_CHECKING:
     from ..provider import OpenIDAuthProvider
@@ -68,13 +69,14 @@ async def template_response(
     template: str, parameters: dict | None = None
 ) -> web.Response:
     """Render a template and return it as an HTML response."""
+    parameters['help_url'] = REPO_ROOT_URL
     return html_response(await get_view(template, parameters))
 
 
 async def error_response(message: str, status: int = 400) -> web.Response:
     """Render the shared error view."""
     return html_response(
-        await get_view("error", {"error": message}),
+        await get_view("error", {"error": message, "help_url": REPO_ROOT_URL}),
         status=status,
         headers={
             "set-cookie": reset_state_cookie(),

--- a/custom_components/auth_oidc/views/templates/_alert.html
+++ b/custom_components/auth_oidc/views/templates/_alert.html
@@ -1,0 +1,28 @@
+{# {% call ui.alert("error") %}message{% endcall %} — type: error|warning|success|info #}
+{% macro alert(type="info") -%}
+{%- set backgrounds = {
+  "error":   "bg-error/12",
+  "warning": "bg-warning/12",
+  "success": "bg-success/12",
+  "info":    "bg-info/12",
+} -%}
+{%- set fills = {
+  "error":   "fill-error",
+  "warning": "fill-warning",
+  "success": "fill-success",
+  "info":    "fill-info",
+} -%}
+{%- set paths = {
+  "error":   "M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z",
+  "warning": "M12,2L1,21H23M12,6L19.53,19H4.47M11,10V14H13V10M11,16V18H13V16",
+  "success": "M12,2C6.5,2 2,6.5 2,12C2,17.5 6.5,22 12,22C17.5,22 22,17.5 22,12C22,6.5 17.5,2 12,2M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M16.59,7.58L10,14.17L7.41,11.59L6,13L10,17L18,9",
+  "info":    "M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z",
+} -%}
+<div class="flex items-start gap-2 rounded p-2 text-left text-sm text-foreground {{ backgrounds.get(type, backgrounds['info']) }}">
+    <!-- mdi icons (all outline, matching HA's ha-alert) — error: alert-circle-outline, warning: alert-outline, success: check-circle-outline, info: information-outline -->
+    <svg viewBox="0 0 24 24" aria-hidden="true" class="h-6 w-6 shrink-0 {{ fills.get(type, fills['info']) }}">
+        <path d="{{ paths.get(type, paths['info']) }}" />
+    </svg>
+    <div class="self-center">{{ caller() }}</div>
+</div>
+{%- endmacro %}

--- a/custom_components/auth_oidc/views/templates/base.html
+++ b/custom_components/auth_oidc/views/templates/base.html
@@ -25,7 +25,7 @@
             {% block content %}{% endblock %}
         </div>
         <div class="flex justify-end pt-2">
-            <a href="https://github.com/christiaangoossens/hass-oidc-auth" target="_blank"
+            <a href="{{ help_url }}" target="_blank"
                 rel="noreferrer noopener"
                 class="inline-flex items-center gap-1 text-sm text-muted hover:text-foreground">
                 Help

--- a/custom_components/auth_oidc/views/templates/base.html
+++ b/custom_components/auth_oidc/views/templates/base.html
@@ -5,15 +5,38 @@
     {% block head %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" href="/static/icons/favicon.ico" />
     <title>{% block title %}{% endblock %}</title>
-    <link rel="stylesheet" href="/auth/oidc/static/style.css?v=2">
+    <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"
+        href="/static/fonts/roboto/Roboto-Regular.woff2">
+    <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"
+        href="/static/fonts/roboto/Roboto-Medium.woff2">
+    <link rel="stylesheet" href="/auth/oidc/static/style.css?v=4">
     {% endblock %}
 </head>
 
-<body class="bg-gray-200 flex items-center justify-center h-full">
-    <div class="bg-white p-6 rounded-lg shadow-lg max-w-md">
-        {% block content %}{% endblock %}
+<body class="bg-background text-foreground flex items-center justify-center min-h-full p-4">
+    {% block layout %}
+    <div class="w-full max-w-sm">
+        <div class="flex items-center justify-center mb-8">
+            <img src="/auth/oidc/static/icon.png?v=1" alt="" class="h-14 w-14">
+        </div>
+        <div class="bg-card text-foreground border border-divider rounded-xl p-4">
+            {% block content %}{% endblock %}
+        </div>
+        <div class="flex justify-end pt-2">
+            <a href="https://github.com/christiaangoossens/hass-oidc-auth" target="_blank"
+                rel="noreferrer noopener"
+                class="inline-flex items-center gap-1 text-sm text-muted hover:text-foreground">
+                Help
+                <!-- mdi: open-in-new -->
+                <svg viewBox="0 0 24 24" aria-hidden="true" class="h-4 w-4 fill-current">
+                    <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
+                </svg>
+            </a>
+        </div>
     </div>
+    {% endblock %}
 </body>
 
 </html>

--- a/custom_components/auth_oidc/views/templates/device_success.html
+++ b/custom_components/auth_oidc/views/templates/device_success.html
@@ -1,14 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Done!{% endblock %}
+{% block title %}Done! - Home Assistant{% endblock %}
 {% block head %}
 {{ super() }}
 {% endblock %}
 {% block content %}
+{% import "_alert.html" as ui %}
 <div class="text-center">
-    <p id="mobile-success-message" class="mb-4">You have successfully logged in on your mobile device. It should continue the login soon. <br/><br/>You have been logged out on this device.</p>
-    <div class="my-6">
-        <a id="restart-login-button" href='/auth/oidc/redirect'
-            class="w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75">Restart</a>
-    </div>
+    <h1 class="mb-4 text-3xl font-normal">Success!</h1>
+    {% call ui.alert('info') %}<span id="mobile-success-message">You have successfully logged in on your mobile device. It should continue the login soon.</span>{% endcall %}
+    <p class="mt-4 mb-6 text-sm text-muted">You have been logged out on this device.</p>
+    <a id="restart-login-button" href='/auth/oidc/redirect'
+        class="inline-flex items-center justify-center w-full h-10 px-4 bg-primary text-white font-medium leading-none rounded-full transition-colors duration-150 ease-out hover:bg-primary-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus">Restart</a>
 </div>
 {% endblock %}

--- a/custom_components/auth_oidc/views/templates/error.html
+++ b/custom_components/auth_oidc/views/templates/error.html
@@ -1,16 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Oops!{% endblock %}
+{% block title %}Oops! - Home Assistant{% endblock %}
 {% block head %}
 {{ super() }}
 {% endblock %}
 {% block content %}
+{% import "_alert.html" as ui %}
 <div class="text-center">
-    <h1 class="text-2xl font-bold mb-4">Login failed.</h1>
-    <p class="mb-4">{{ error }}</p>
-    <div class="my-6">
-        <a href='/auth/oidc/redirect'
-            class="w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75">Try
-            again</a>
-    </div>
+    <h1 class="mb-4 text-3xl font-normal">Login failed.</h1>
+    {% call ui.alert('error') %}{{ error }}{% endcall %}
+    <a href='/auth/oidc/redirect'
+        class="inline-flex items-center justify-center w-full h-10 px-4 bg-primary text-white font-medium leading-none rounded-full mt-6 transition-colors duration-150 ease-out hover:bg-primary-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus">Try
+        again</a>
 </div>
 {% endblock %}

--- a/custom_components/auth_oidc/views/templates/finish.html
+++ b/custom_components/auth_oidc/views/templates/finish.html
@@ -1,33 +1,33 @@
 {% extends "base.html" %}
-{% block title %}Logged in!{% endblock %}
+{% block title %}Logged in! - Home Assistant{% endblock %}
 {% block head %}
 {{ super() }}
 {% endblock %}
 {% block content %}
 <div>
-    <h1 class="text-2xl font-bold mb-4 text-center">Logged in!</h1>
-
-    <div class="mb-4 rounded-lg border border-gray-300 bg-gray-50 p-6 text-left">
-        <h2 class="mb-2 text-lg font-semibold text-gray-800">Continue on this device</h2>
-        <p class="mb-4 text-sm text-gray-600">Tap Continue to login to Home Assistant on this device.</p>
+    <h1 class="mb-4 text-center text-3xl font-normal">Logged in!</h1>
+    <div class="mb-4 rounded-lg border border-divider bg-background p-6 text-left">
+        <h2 class="mb-2 text-lg font-medium text-foreground">Continue on this device</h2>
+        <p class="mb-4 text-sm text-muted">Tap Continue to login to Home Assistant on this device.</p>
         <form method="post">
             <button
                 id="continue-on-this-device"
                 type="submit"
-                class="w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg 
-                    shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 
-                    focus:ring-opacity-75 hover:cursor-pointer"
+                class="inline-flex items-center justify-center w-full h-10 px-4 bg-primary text-white font-medium leading-none rounded-full
+                    transition-colors duration-150 ease-out hover:bg-primary-hover
+                    focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus
+                    hover:cursor-pointer"
             >
                 Continue on this device
             </button>
         </form>
     </div>
 
-    <div class="rounded-lg border border-gray-300 bg-white p-6 text-left">
-        <h2 class="mb-2 text-lg font-semibold text-gray-800">Use a code from another device</h2>
-        <p class="mb-2 text-sm text-gray-600">On your other device, open the Home Assistant app. You will see a
+    <div class="rounded-lg border border-divider bg-background p-6 text-left">
+        <h2 class="mb-2 text-lg font-medium text-foreground">Use a code from another device</h2>
+        <p class="mb-2 text-sm text-muted">On your other device, open the Home Assistant app. You will see a
                 6-digit code.</p>
-            <p class="mb-4 text-sm text-gray-600">Input that code here and click Approve to login on the other device.
+            <p class="mb-4 text-sm text-muted">Input that code here and click Approve to login on the other device.
             </p>
             <form method="post">
                 <div>
@@ -40,19 +40,18 @@
                         maxlength="6"
                         pattern="[0-9]{6}"
                         inputmode="numeric"
-                        placeholder="123456" 
-                        class="mb-2 w-full rounded-md border border-gray-300 px-5 py-3 text-center text-base 
-                        tracking-[0.15em] text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400
-                         focus:ring-opacity-75"
+                        placeholder="123456"
+                        class="mb-4 h-14 w-full rounded-t-lg border-b-2 border-input-border bg-input px-4 text-center text-base
+                        tracking-[0.15em] text-foreground placeholder:text-muted transition-colors
+                        hover:bg-input-hover focus:border-primary focus:outline-none"
                         >
                 </div>
                 <button 
                     id="approve-login-button"
                     type="submit"
-                    class="w-full py-2 px-4 bg-white text-blue-600 
-                        font-semibold rounded-lg border border-blue-500 shadow-md hover:bg-gray-100
-                        hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 
-                        focus:ring-opacity-75 hover:cursor-pointer"
+                    class="inline-flex items-center justify-center w-full h-10 px-4 bg-card text-primary
+                        font-medium leading-none rounded-full border border-primary transition-colors duration-150 ease-out hover:bg-input
+                        focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus hover:cursor-pointer"
                     >
                     Approve login on the other device
                 </button>

--- a/custom_components/auth_oidc/views/templates/redirect.html
+++ b/custom_components/auth_oidc/views/templates/redirect.html
@@ -1,22 +1,16 @@
 {% extends "base.html" %}
-{% block title %}OIDC Redirect{% endblock %}
+{% block title %}OIDC Redirect - Home Assistant{% endblock %}
 {% block head %}
 {{ super() }}
 {% endblock %}
-{% block content %}
-<div class="text-center">
-    <div role="status" id="loader" class="items-center justify-center flex">
-        <svg aria-hidden="true" class="w-10 h-10 text-gray-200 animate-spin fill-blue-600" viewBox="0 0 100 101"
-            fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-                d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                fill="currentColor" />
-            <path
-                d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                fill="currentFill" />
-        </svg>
-        <span class="sr-only">Redirecting...</span>
-    </div>
+{% block layout %}
+<div role="status" id="loader">
+    <svg class="h-12 w-12 animate-spin" viewBox="0 0 48 48" fill="none" aria-hidden="true">
+        <circle class="stroke-divider" cx="24" cy="24" r="20" stroke-width="4" />
+        <circle class="stroke-primary" cx="24" cy="24" r="20" stroke-width="4" stroke-linecap="round"
+            stroke-dasharray="31.4 94.3" />
+    </svg>
+    <span class="sr-only">Redirecting...</span>
 </div>
 <script>
     // Redirect after loading the page to show the redirect visual

--- a/custom_components/auth_oidc/views/templates/welcome.html
+++ b/custom_components/auth_oidc/views/templates/welcome.html
@@ -6,7 +6,6 @@
 {% block content %}
 {% import "_alert.html" as ui %}
 <div class="text-center">
-    <h1 class="mb-4 text-3xl font-normal">Log in</h1>
     {% if code %}
         <div>
             <p id="device-instructions">Please login to Home Assistant on another device and enter this code when asked:</p>
@@ -59,7 +58,7 @@
             border border-divider transition-colors duration-150 ease-out hover:bg-input
             focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus
         ">
-            Default login
+            Default login (username & password)
         </a>
     {% endif %}
 </div>

--- a/custom_components/auth_oidc/views/templates/welcome.html
+++ b/custom_components/auth_oidc/views/templates/welcome.html
@@ -1,19 +1,21 @@
 {% extends "base.html" %}
-{% block title %}OIDC Login{% endblock %}
+{% block title %}OIDC Login - Home Assistant{% endblock %}
 {% block head %}
 {{ super() }}
 {% endblock %}
 {% block content %}
+{% import "_alert.html" as ui %}
 <div class="text-center">
+    <h1 class="mb-4 text-3xl font-normal">Log in</h1>
     {% if code %}
         <div>
             <p id="device-instructions">Please login to Home Assistant on another device and enter this code when asked:</p>
-            <div class="mt-4 text-3xl tracking-wide font-bold bg-gray-100 border border-gray-300 rounded-lg py-4 px-6 inline-block" id="device-code">
+            <div class="mt-4 text-3xl tracking-wide font-medium bg-input border border-divider rounded-lg py-4 px-6 inline-block" id="device-code">
                 {{ code }}
             </div>
-            <p class="mt-4 text-sm text-gray-600">
-                The login will continue automatically when you complete the login on your other device. Please keep the app open.
-            </p>
+            <div class="mt-4">
+                {% call ui.alert('info') %}The login will continue automatically when you complete the login on your other device. Please keep the app open.{% endcall %}
+            </div>
         </div>
         <script>
             const source = new EventSource('/auth/oidc/device-sse');
@@ -34,21 +36,31 @@
             });
         </script>
     {% else %}
-        <div>
-                <a id="login-button" href="/auth/oidc/redirect" class="
-                    w-full py-2 px-4 bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 
-                    focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75
-                    hover:cursor-pointer
-                ">
+        <a id="login-button" href="/auth/oidc/redirect" class="
+            inline-flex items-center justify-center w-full h-10 px-4 bg-primary text-white font-medium leading-none rounded-full
+            transition-colors duration-150 ease-out hover:bg-primary-hover
+            focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus
+        ">
                 Login with {{ name }}
             </a>
-        </div>
     {% endif %}
 
     {% if other_link %}
-        <p class=" mt-4 text-sm text-center">
-            <a id="alternative-sign-in-link" href="{{ other_link }}" class="text-gray-600 hover:underline">Continue with default login</a>
-        </p>
+        <div class="relative my-4">
+            <div class="absolute inset-0 flex items-center" aria-hidden="true">
+                <div class="w-full border-t border-divider"></div>
+            </div>
+            <div class="relative flex justify-center">
+                <span class="bg-card px-4 text-sm text-muted">Or log in with</span>
+            </div>
+        </div>
+        <a id="alternative-sign-in-link" href="{{ other_link }}" class="
+            inline-flex items-center justify-center w-full h-10 px-4 bg-card text-foreground font-medium leading-none rounded-full
+            border border-divider transition-colors duration-150 ease-out hover:bg-input
+            focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus
+        ">
+            Default login
+        </a>
     {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Follow-up to #355. Rebuilds the auth callback templates using Tailwind v4 semantic tokens mapped to HA theme variables, with `prefers-color-scheme` media queries for light/dark mode.

- Semantic colour tokens mapped to HA variable names via `@theme inline`
- Integration brand icon replaces HA logo
- Roboto typography from HA's same-origin fonts
- HA-style alert boxes (Jinja macro), divider, footer help link
- Card, buttons, input, headings, and spinner now match HA's authorize page
- HA favicon linked, page titles suffixed to match Home Assistant

9 files, +220 / −70

Screenshots:
<img width="1024" height="640" alt="device_success" src="https://github.com/user-attachments/assets/255def91-1167-4287-a06d-0ec612a07f24" />
<img width="1024" height="640" alt="error" src="https://github.com/user-attachments/assets/7d702097-fb3a-434c-b46d-3f3d24782256" />
<img width="1024" height="640" alt="finish" src="https://github.com/user-attachments/assets/b4a89d56-c751-4169-a200-9260e365a263" />
<img width="1024" height="640" alt="redirect" src="https://github.com/user-attachments/assets/c0cb0762-b240-4b12-86d9-07099bf9ee2f" />
<img width="1024" height="640" alt="welcome" src="https://github.com/user-attachments/assets/94d87389-26d1-4e97-a549-5e5eccc34399" />
<img width="1024" height="640" alt="welcome-code" src="https://github.com/user-attachments/assets/ca53672f-b451-492f-8e64-4de7cce41f38" />
