### PR TITLE
fix: broaden grant type validation to accept authorization_code_with_pkce

### DIFF
--- a/custom_components/auth_oidc/tools/oidc_client.py
+++ b/custom_components/auth_oidc/tools/oidc_client.py
@@ -196,8 +196,10 @@ class OIDCDiscoveryClient:
                 )
 
         # If grant_types_supported is set, should support 'authorization_code'
+        # or 'authorization_code_with_pkce'
+        supported_grant_types = {"authorization_code", "authorization_code_with_pkce"}
         if "grant_types_supported" in document:
-            if "authorization_code" not in document["grant_types_supported"]:
+            if supported_grant_types.isdisjoint(document["grant_types_supported"]):
                 _LOGGER.warning(
                     "Error: Discovery document %s does not support required "
                     "'authorization_code' grant type, only supports: %s",

--- a/custom_components/auth_oidc/tools/oidc_client.py
+++ b/custom_components/auth_oidc/tools/oidc_client.py
@@ -202,14 +202,15 @@ class OIDCDiscoveryClient:
             if supported_grant_types.isdisjoint(document["grant_types_supported"]):
                 _LOGGER.warning(
                     "Error: Discovery document %s does not support required "
-                    "'authorization_code' grant type, only supports: %s",
+                    "authorization code grant type (%s), only supports: %s",
                     self.discovery_url,
+                    "'authorization_code' or 'authorization_code_with_pkce'",
                     document["grant_types_supported"],
                 )
                 raise OIDCDiscoveryInvalid(
                     type="does_not_support_grant_type",
                     details={
-                        "required": "authorization_code",
+                        "required": "'authorization_code' or 'authorization_code_with_pkce'",
                         "supported": document["grant_types_supported"],
                     },
                 )

--- a/tests/mocks/scenarios/only_pkce_grant_type.json
+++ b/tests/mocks/scenarios/only_pkce_grant_type.json
@@ -1,0 +1,10 @@
+{
+    "discovery": {
+        "issuer": "https://mock-oidc-server.local",
+        "authorization_endpoint": "https://mock-oidc-server.local/authorize",
+        "token_endpoint": "https://mock-oidc-server.local/token",
+        "jwks_uri": "https://mock-oidc-server.local/jwks",
+        "grant_types_supported": ["authorization_code_with_pkce"],
+        "id_token_signing_alg_values_supported": ["RS256"]
+    }
+}

--- a/tests/test_hass_oidc_client_integration.py
+++ b/tests/test_hass_oidc_client_integration.py
@@ -403,7 +403,7 @@ async def test_discovery_failures(hass: HomeAssistant, hass_client, caplog):
         hass_client,
         caplog,
         "invalid_grant_types",
-        "does not support required 'authorization_code' grant type, only supports: ['refresh_token']",
+        "does not support required authorization code grant type ('authorization_code' or 'authorization_code_with_pkce'), only supports: ['refresh_token']",
     )
     await direct_discovery_test(
         hass, "invalid_grant_types", "does_not_support_grant_type", "refresh_token"

--- a/tests/test_hass_oidc_client_integration.py
+++ b/tests/test_hass_oidc_client_integration.py
@@ -475,6 +475,23 @@ async def test_discovery_failures(hass: HomeAssistant, hass_client, caplog):
 
 
 @pytest.mark.asyncio
+async def test_discovery_accepts_pkce_only_grant_type(hass: HomeAssistant):
+    """Test discovery validation accepts providers advertising only PKCE grant type."""
+    with mock_oidc_responses("only_pkce_grant_type"):
+        session = async_get_clientsession(hass)
+        client = OIDCDiscoveryClient(
+            MockOIDCServer.get_discovery_url(),
+            session,
+            {
+                "id_token_signing_alg": "RS256",
+            },
+        )
+
+        document = await client.fetch_discovery_document()
+        assert document["grant_types_supported"] == ["authorization_code_with_pkce"]
+
+
+@pytest.mark.asyncio
 async def test_direct_jwks_fetch(hass: HomeAssistant):
     """Test direct fetch of JWKS."""
     with mock_oidc_responses():


### PR DESCRIPTION
## Summary

Some OIDC providers advertise `authorization_code_with_pkce` instead of — or
alongside — `authorization_code` in their `grant_types_supported` discovery field.

The previous validation strictly required `authorization_code` to be present,
which would incorrectly reject such providers.

## Changes

- Updated `_validate_discovery_document` to accept either `authorization_code` or
  `authorization_code_with_pkce` as a valid grant type, using `isdisjoint` to raise
  an error only when neither is present.

## Testing

Added regression test.