### PR TITLE
Fix device-code login getting stuck when the SSE connection drops

### DIFF
--- a/custom_components/auth_oidc/views/templates/welcome.html
+++ b/custom_components/auth_oidc/views/templates/welcome.html
@@ -15,11 +15,13 @@
             <div class="mt-4">
                 {% call ui.alert('info') %}The login will continue automatically when you complete the login on your other device. Please keep the app open.{% endcall %}
             </div>
-            <p class="mt-4">
+            <!-- Temporarily not shown until https://github.com/christiaangoossens/hass-oidc-auth/issues/300 is picked up -->
+            <!-- Currently sends you to a weird error when clicked before ready -->
+            <!-- <p class="mt-4">
                 <a id="manual-finish-link" href="#" class="text-sm text-muted hover:text-foreground">
                     Already approved the code, but nothing happened? Click here to continue.
                 </a>
-            </p>
+            </p> -->
         </div>
         <script>
             const source = new EventSource('/auth/oidc/device-sse');

--- a/custom_components/auth_oidc/views/templates/welcome.html
+++ b/custom_components/auth_oidc/views/templates/welcome.html
@@ -15,11 +15,16 @@
             <div class="mt-4">
                 {% call ui.alert('info') %}The login will continue automatically when you complete the login on your other device. Please keep the app open.{% endcall %}
             </div>
+            <p class="mt-4">
+                <a id="manual-finish-link" href="#" class="text-sm text-muted hover:text-foreground">
+                    Already approved the code, but nothing happened? Click here to continue.
+                </a>
+            </p>
         </div>
         <script>
             const source = new EventSource('/auth/oidc/device-sse');
 
-            source.addEventListener('ready', function () {
+            function finishLogin() {
                 source.close();
 
                 // Perform a POST request to the finish endpoint to complete the login.
@@ -28,10 +33,22 @@
                 form.action = '/auth/oidc/finish';
                 document.body.appendChild(form);
                 form.submit();
-            });
+            }
 
-            source.addEventListener('error', function () {
-                source.close();
+            source.addEventListener('ready', finishLogin);
+
+            // No 'error' handler that closes the source: EventSource
+            // reconnects automatically after a dropped connection, e.g.
+            // when the OS suspends this webview while the user enters the
+            // code in their browser (#363). On reconnect, the server
+            // immediately sends 'ready' if the code was approved in the
+            // meantime. Fatal responses (such as a 400 after state expiry)
+            // stop the automatic reconnection on their own.
+
+            // Manual fallback in case the connection cannot be resumed.
+            document.getElementById('manual-finish-link').addEventListener('click', function (event) {
+                event.preventDefault();
+                finishLogin();
             });
         </script>
     {% else %}


### PR DESCRIPTION
## Problem

When logging in through the companion app, the code screen holds an `EventSource` connection to `/auth/oidc/device-sse`. On a phone, entering the code requires switching to a browser — at which point the OS suspends the app's webview and the SSE connection drops. The current error handler closes the source permanently:

```js
source.addEventListener('error', function () {
    source.close();
});
```

So even though the code was approved server-side, the app never hears the `ready` event and the code screen hangs forever. Reproduced on iOS (backgrounding kills the socket within seconds); #363 reports the same on Samsung devices, whose battery management is similarly aggressive.

## Fix

1. **Let `EventSource` auto-reconnect.** Removed the `close()` on error — reconnection is EventSource's default behavior. On reconnect, the server-side polling loop immediately emits `ready` if the state was approved while disconnected. Fatal responses (e.g. 400 after state expiry) already stop reconnection per the SSE spec, so this can't retry forever against a dead state.

2. **Manual fallback link** ("Already approved the code, but nothing happened? Click here to continue.") that submits the same finish form as the `ready` handler — the manual 'check for complete login' link you proposed in #363. It covers webviews where the SSE connection cannot resume at all (Samsung Browser behavior discussed in that issue).

Both paths go through the existing `POST /auth/oidc/finish` with no body, identical to the current `ready` handler, so no server-side changes are needed. The link reuses class combinations already present in `base.html` (`text-sm text-muted hover:text-foreground`), so no CSS rebuild is required.

## Testing

**Root cause confirmed on a live instance** (HA 2026.6.4 + authentik, v1.1.1 via the release zip): same-device flow on iOS — app shows code → switch to Safari → approve → return to app — leaves the code screen hung, while the state is approved server-side.

**Patched template verified in headless Chromium** against a stub server that renders these Jinja templates and reproduces the failure (first SSE connection killed mid-stream without a terminal event; state approved while disconnected):

| Template | Scenario | SSE connections | Outcome |
|---|---|---|---|
| current `main` | connection drop | 1 (never reconnects) | hangs forever |
| patched | connection drop | 2 (auto-reconnect) | `ready` received, finish form posted |
| patched | SSE fatally dead (400) | 1 | finish form posted via manual link |

Python is untouched, so lint/tests are unaffected. Happy to also report back results from a patched install on real iOS/Android devices if useful.

Fixes #363