### PR TITLE
Baseline Device Code and UX Groundwork

### DIFF
--- a/custom_components/auth_oidc/static/ux-router-eval.js
+++ b/custom_components/auth_oidc/static/ux-router-eval.js
@@ -1,0 +1,18 @@
+
+export const PresentationStrategy = Object.freeze({
+    AUTO_REDIRECT: "auto_redirect", // Auto redirects to Home Assistant login page on desktop (not implemented)
+    MOBILE_APP: "mobile_app", //device flow autostarts on companion app (QR shows on tablet size [not implemented])
+    TABLET_TV: "tablet_tv", // QR codes shown on smart tv / tablet devices [not implemented]
+    AMBIGUOUS: "ambiguous", // device code option shown as well as redirect option shown (default when above situations not detected)
+});
+
+
+export function decideStrategy() {
+    const isCompanionApp = (document.querySelector("meta[name='is_companion_app']").getAttribute("content") ?? 'false') == "true";
+
+    if (isCompanionApp) {
+        return PresentationStrategy.MOBILE_APP;
+    }
+
+    return PresentationStrategy.AMBIGUOUS;
+}

--- a/custom_components/auth_oidc/tools/oidc_client.py
+++ b/custom_components/auth_oidc/tools/oidc_client.py
@@ -340,7 +340,7 @@ class OIDCClient:
         # HA never seems to run this, but it's good practice to close the session
         if self.http_session:
             _LOGGER.debug("Closing HTTP session")
-            self.http_session.close()
+            self.http_session.close() # TODO: check with maintainer if this should be awaited
 
     def _base64url_encode(self, value: str) -> str:
         """Uses base64url encoding on a given string"""

--- a/custom_components/auth_oidc/tools/session_state.py
+++ b/custom_components/auth_oidc/tools/session_state.py
@@ -59,3 +59,4 @@ class OIDCPending(OIDCState):
 class OIDCDeviceApproving(OIDCRedirectState):
     flow_type: Literal["device_approving"] = "device_approving"
     device_code: str | None = None
+    current_device_code_attempt: int | None = 0

--- a/custom_components/auth_oidc/tools/session_state.py
+++ b/custom_components/auth_oidc/tools/session_state.py
@@ -1,0 +1,61 @@
+
+
+from datetime import datetime
+from custom_components.auth_oidc.tools.types import UserDetails
+from dataclasses import dataclass
+from typing import Dict, Any, Literal
+
+
+@dataclass
+class OIDCState:
+    id: str
+    flow_type: str = "pending"
+    redirect_uri: str = "/"
+    user_details: UserDetails | None = None
+    ip_address: str | None = None
+    expiration: datetime | None = None
+    
+    def is_expired(self) -> bool:
+        if self.expiration is None:
+            return False
+        return self.expiration < datetime.now()
+
+    @classmethod
+    def init_from_dict(cls, data: Dict[str, Any]) -> OIDCState: 
+        flow_type = data.get("flow_type", "pending")
+        flow_classes = {   
+            "device_waiting": OIDCDeviceWaiting,
+            "redirect": OIDCRedirectState,
+            "pending": OIDCPending,
+            "device_approving": OIDCDeviceApproving,
+        }
+        target_class = flow_classes.get(flow_type, OIDCState)
+        return target_class(**data)
+
+@dataclass
+class OIDCDeviceWaiting(OIDCState):
+    flow_type: Literal["device_waiting"] = "device_waiting"
+    
+    status: Literal["pending", "ready", "expired", "denied"] = "pending"
+    user_code: str | None = None
+    verification_uri: str | None = None
+    device_code: str | None = None
+    expires_in: int | None = None
+    interval: int | None = None
+    started_at: int | None = None
+
+@dataclass
+class OIDCRedirectState(OIDCState):
+    flow_type: Literal["redirect", "device_approving"] = "redirect"
+
+@dataclass
+class OIDCPending(OIDCState):
+    '''
+    State for client directed to welcome screen to choose a flow mode
+    '''
+    flow_type: Literal["pending"] = "pending"
+
+@dataclass
+class OIDCDeviceApproving(OIDCRedirectState):
+    flow_type: Literal["device_approving"] = "device_approving"
+    device_code: str | None = None

--- a/custom_components/auth_oidc/tools/session_state.py
+++ b/custom_components/auth_oidc/tools/session_state.py
@@ -1,5 +1,4 @@
-
-
+"""OIDC Session state models"""
 from datetime import datetime
 from custom_components.auth_oidc.tools.types import UserDetails
 from dataclasses import dataclass
@@ -14,16 +13,16 @@ class OIDCState:
     user_details: UserDetails | None = None
     ip_address: str | None = None
     expiration: datetime | None = None
-    
+
     def is_expired(self) -> bool:
         if self.expiration is None:
             return False
         return self.expiration < datetime.now()
 
     @classmethod
-    def init_from_dict(cls, data: Dict[str, Any]) -> OIDCState: 
+    def init_from_dict(cls, data: Dict[str, Any]) -> OIDCState:
         flow_type = data.get("flow_type", "pending")
-        flow_classes = {   
+        flow_classes = {
             "device_waiting": OIDCDeviceWaiting,
             "redirect": OIDCRedirectState,
             "pending": OIDCPending,
@@ -32,10 +31,11 @@ class OIDCState:
         target_class = flow_classes.get(flow_type, OIDCState)
         return target_class(**data)
 
+
 @dataclass
 class OIDCDeviceWaiting(OIDCState):
     flow_type: Literal["device_waiting"] = "device_waiting"
-    
+
     status: Literal["pending", "ready", "expired", "denied"] = "pending"
     user_code: str | None = None
     verification_uri: str | None = None
@@ -44,16 +44,20 @@ class OIDCDeviceWaiting(OIDCState):
     interval: int | None = None
     started_at: int | None = None
 
+
 @dataclass
 class OIDCRedirectState(OIDCState):
     flow_type: Literal["redirect", "device_approving"] = "redirect"
 
+
 @dataclass
 class OIDCPending(OIDCState):
-    '''
+    """
     State for client directed to welcome screen to choose a flow mode
-    '''
+    """
+
     flow_type: Literal["pending"] = "pending"
+
 
 @dataclass
 class OIDCDeviceApproving(OIDCRedirectState):

--- a/custom_components/auth_oidc/views/templates/base.html
+++ b/custom_components/auth_oidc/views/templates/base.html
@@ -5,6 +5,7 @@
     {% block head %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="is_companion_app" content="{{ (is_mobile or False) | lower }}">
     <link rel="icon" href="/static/icons/favicon.ico" />
     <title>{% block title %}{% endblock %}</title>
     <link rel="preload" as="font" type="font/woff2" crossorigin="anonymous"

--- a/docs/.internal-refractor-notes/high-level.md
+++ b/docs/.internal-refractor-notes/high-level.md
@@ -4,9 +4,36 @@
 
 - [ ] client_id is still important to identify the home assistant mobile app companion
   - [ ] Backend will need to pass html metadata for front end to interpret and change presentation
-- [ ] Investigate how backend session tracking works and adapt it to track device code status
+- [x] Investigate how backend session tracking works and adapt it to track device code status (See [investigate backend notes](#investigate-backend-tracking-notes))
 - [ ] Device code endpoint with for post url encoded and get app html needs to be strictly authenticated via external IdP and tracked via session cookie
   - Might move this to a dedicated endpoint opposed to the PR description as `/auth/oidc/log-device`. We have `/auth/oidc/device` doing 4 things (2 get and 2 post each) which makes things a bit confusing. Just a bit 😛.
 - [ ] Migrate the SSE logic that exists to a pub/sub model rather than polling
 - [ ] Move html and js code to dedicated files for cleaner code (I personally feel that combining JS into HTML is messy and should only be down as absolutely necessary [ie. templating via Jinja2 or PHP])
 - [ ] Code for front end and device workers should be written deliberately open to allow for mixins in future PRs. I'm favoring class inheritance.
+
+
+### Investigate backend tracking notes
+
+#### Current Mechanism
+- **Storage Engine**: `StateStore` uses Home Assistant's `Store` helper (`homeassistant.helpers.storage.Store`) persisting to `.storage/auth_provider.auth_oidc.states`.
+- **Cookie Link**: Sessions are bound to the `auth_oidc_state` HTTP cookie (`state_id`).
+- **JSON Serialization**: `OIDCState` inherits directly from `dict` (`class OIDCState(dict)`), allowing HA to save/load it directly to/from JSON without custom converters.
+- **Donor Pattern**: Device linking currently copies `user_details` from an authenticated secondary device session into the waiting session and deletes the secondary device session.
+
+#### Categorizing Sessions via `flow_type` & Nested `flow_data`
+To prevent `OIDCState` from becoming an unstructured flat dictionary, sessions are categorized into 3 explicit flow types:
+1. **`redirect`**: Standard OAuth browser redirect flow.
+2. **`device_waiting`**: Client/TV waiting for authorization (`POST /auth/oidc/device` -> `GET /auth/oidc/device-sse`).
+3. **`device_approving`**: Secondary device (phone/PC) authenticating via OIDC first, then entering the user code at `/auth/oidc/log-device`.
+
+#### Extended Session Schema Proposal
+When `POST /auth/oidc/device` initiates a `device_waiting` flow, it populates a nested `flow_data` dictionary:
+- `status`: `"pending" | "ready" | "expired" | "denied"`
+- `user_code` & `verification_uri`: Returned in POST response & displayed on screen.
+- `device_code`: Kept in backend for IdP polling or local matching.
+- `expires_in` & `interval`: Provided by external IdP (or default 300s / 5min for local fallback).
+- `started_at`: Epoch timestamp for dynamic SSE & polling timeout calculations.
+
+#### Key Architectural Rules
+- **Strict Execution Order**: `POST /auth/oidc/device` **must** happen before `GET /auth/oidc/device-sse`. The SSE endpoint validates the session created during `POST` and calculates remaining TTL dynamically using `expires_in` and `started_at`.
+- **Pub/Sub Event Signaling**: Replaces the `while True: await asyncio.sleep(0.5)` busy-wait loop in `device_sse.py`. When `/auth/oidc/log-device` transfers `user_details` to the recipient `state_id`, it sets `status = "ready"` and triggers an `asyncio.Event` signal to unblock the SSE stream instantly.

--- a/docs/.internal-refractor-notes/high-level.md
+++ b/docs/.internal-refractor-notes/high-level.md
@@ -1,0 +1,12 @@
+# High level notes on refactoring
+
+## Big things to keep in mind
+
+- [ ] client_id is still important to identify the home assistant mobile app companion
+  - [ ] Backend will need to pass html metadata for front end to interpret and change presentation
+- [ ] Investigate how backend session tracking works and adapt it to track device code status
+- [ ] Device code endpoint with for post url encoded and get app html needs to be strictly authenticated via external IdP and tracked via session cookie
+  - Might move this to a dedicated endpoint opposed to the PR description as `/auth/oidc/log-device`. We have `/auth/oidc/device` doing 4 things (2 get and 2 post each) which makes things a bit confusing. Just a bit 😛.
+- [ ] Migrate the SSE logic that exists to a pub/sub model rather than polling
+- [ ] Move html and js code to dedicated files for cleaner code (I personally feel that combining JS into HTML is messy and should only be down as absolutely necessary [ie. templating via Jinja2 or PHP])
+- [ ] Code for front end and device workers should be written deliberately open to allow for mixins in future PRs. I'm favoring class inheritance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "hass-oidc-auth",
       "dependencies": {
         "@tailwindcss/cli": "^4.1.14",
+        "qrcode": "^1.5.4",
         "tailwindcss": "^4.1.14"
       }
     },
@@ -177,9 +178,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -199,9 +197,6 @@
       "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -223,9 +218,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -245,9 +237,6 @@
       "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -269,9 +258,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -291,9 +277,6 @@
       "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -511,9 +494,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -529,9 +509,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -549,9 +526,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +541,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -607,25 +578,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -701,6 +653,30 @@
         "node": ">= 20"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -711,6 +687,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/detect-libc": {
@@ -724,6 +747,18 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
@@ -750,6 +785,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -763,6 +820,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -931,9 +997,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -953,9 +1016,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -977,9 +1037,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -999,9 +1056,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1065,6 +1119,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1102,6 +1168,51 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1120,6 +1231,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1127,6 +1285,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tailwindcss": {
@@ -1158,6 +1342,67 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@tailwindcss/cli": "^4.1.14",
+    "qrcode": "^1.5.4",
     "tailwindcss": "^4.1.14"
   }
 }

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,15 @@
+This is a draft PR to refractor the existing device code functionality into enabling support for external idP device code flows. This PR is focused on setting the foundation, including front end routing logic, for the device auth flow. But, the specialized front end routing logic will be deferred to later PR's. The focus of this PR is to create additional endpoints to increase separation of concerns between normal OAuth/OIDC flows and device code flows and setting the bedrock for the front end routing logic for detecting the device type and UX of the client requesting authentication/authorization. Finally, this PR will introduce an endpoint at `/device` that will allow the device code fallback (incase the IdP does not support device codes) to use the built-in device code flow. Finally, the device code flow that the front end (the user device) connects to the backend (the Home Assistant instance) may favor using SSE over polling despite the standard being for polling while the backend will handle the polling to the IdP (Authentik/another provider).
+
+> [!NOTE]
+> This PR will not address discussion #350 at this time and will be followed up in a separate PR.
+
+## Proposed endpoints:
+
+- `/device`: endpoint that user is directed to enter activation code in case that the IdP device code flow is unavailable. This is strictly authenticated and requires the user to get authorized through normal OAuth/OIDC flow first, even if they have a valid session cookie with the main HA instance.
+- `/auth/oidc/device`: endpoint for the front end to begin the device code flow after UX routing logic completes on the front end. This endpoint begins the SSE where the backend handles the polling for as long as the SSE connection remains open. This connection closes automatically after the flow completes and the client is redirected.
+- `/auth/oidc/redirect`: Remains functionally the same, except that it is still explicitly choosen by the front end UX logic. The backend does not know nor does it care if it is a device flow or normal flow. It is up to the front end to route accordingly, whether that be by user input or the front end routing logic completing automatically.
+
+## PR Context
+
+This PR is supposed to address issue #300 and move discussion from #349 to this PR. Furthmore, this proposal is peliminary and will be updated as I further research the codebase.
+

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,15 +1,57 @@
-This is a draft PR to refractor the existing device code functionality into enabling support for external idP device code flows. This PR is focused on setting the foundation, including front end routing logic, for the device auth flow. But, the specialized front end routing logic will be deferred to later PR's. The focus of this PR is to create additional endpoints to increase separation of concerns between normal OAuth/OIDC flows and device code flows and setting the bedrock for the front end routing logic for detecting the device type and UX of the client requesting authentication/authorization. Finally, this PR will introduce an endpoint at `/device` that will allow the device code fallback (incase the IdP does not support device codes) to use the built-in device code flow. Finally, the device code flow that the front end (the user device) connects to the backend (the Home Assistant instance) may favor using SSE over polling despite the standard being for polling while the backend will handle the polling to the IdP (Authentik/another provider).
+This is a draft PR to refactor the existing device code functionality to enable support for external IdP device code flows. This PR is focused on setting the backend foundation—including endpoint restructuring and internal state management—for the device auth flow. While highly specialized frontend routing logic will be deferred to later PRs, this PR establishes the bedrock: cleanly separating normal OAuth/OIDC flows from device code flows. 
+
+Specifically, this PR introduces new `/auth/oidc/*` endpoints to handle the device code fallback locally (in case the IdP does not support device codes) and establishes a decoupled Server-Sent Events (SSE) pattern. By using SSE, our custom JS frontend on the Welcome Screen can seamlessly listen for backend state changes while an abstracted backend worker handles the actual polling of the IdP (e.g., Authentik). Standard HTTP polling of the device endpoint is also supported as a fallback to future-proof for third-party clients.
 
 > [!NOTE]
 > This PR will not address discussion #350 at this time and will be followed up in a separate PR.
 
 ## Proposed endpoints:
 
-- `/device`: endpoint that user is directed to enter activation code in case that the IdP device code flow is unavailable. This is strictly authenticated and requires the user to get authorized through normal OAuth/OIDC flow first, even if they have a valid session cookie with the main HA instance.
-- `/auth/oidc/device`: endpoint for the front end to begin the device code flow after UX routing logic completes on the front end. This endpoint begins the SSE where the backend handles the polling for as long as the SSE connection remains open. This connection closes automatically after the flow completes and the client is redirected.
-- `/auth/oidc/redirect`: Remains functionally the same, except that it is still explicitly choosen by the front end UX logic. The backend does not know nor does it care if it is a device flow or normal flow. It is up to the front end to route accordingly, whether that be by user input or the front end routing logic completing automatically.
+- `/auth/oidc/device` (GET): Endpoint that the user is directed to on a secondary device to enter the activation code (fallback for when IdP device code flow is unavailable). This requires the user to get authorized through the normal OAuth/OIDC flow first.
+- `/auth/oidc/device` (POST): Endpoint for the client to explicitly initiate the device code flow after UX routing logic completes. This triggers the backend to begin background polling with the IdP and provides the client with a session token cookie. The client may also use this endpoint to poll for the status of the device code flow in line to the OIDC standard for device code flows. However, SSE is the preferred method for clients that are running the front end code provided by this integration.
+- `/auth/oidc/device-sse` (GET): Endpoint the client connects to for Server-Sent Events (SSE) after initiation. The backend matches the request based on the session token cookie provided by the initiation POST request. A direct request to this endpoint without the device flow being initiated will be rejected.
+- `/auth/oidc/redirect`: Remains functionally the same, except that it is explicitly chosen by the frontend UX logic. The backend remains agnostic to the flow type; it relies on the frontend to route accordingly based on device detection or user input.
 
 ## PR Context
 
-This PR is supposed to address issue #300 and move discussion from #349 to this PR. Furthmore, this proposal is peliminary and will be updated as I further research the codebase.
+This PR is supposed to address issue #300 and move discussion from #349 to this PR. Furthermore, this proposal is preliminary and will be updated as I further research the codebase.
+
+## Decoupled Device Flow Diagram
+
+The following sequence diagram illustrates how the frontend SSE connection is decoupled from the actual background polling task (which handles either the external IdP device flow or the internal fallback flow).
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant JS as JS Frontend (Welcome Screen)
+    participant HA_Dev as POST /auth/oidc/device
+    participant Worker as Backend Worker
+    participant HA_SSE as GET /auth/oidc/device-sse
+    
+    Note over User, JS: User is redirected to authenticate and brought to Welcome screen.
+    
+    User->>JS: Selects "Device Code" login flow
+    
+    JS->>HA_Dev: Initiates POST request
+    HA_Dev->>Worker: Sets status in DB & spawns worker
+    HA_Dev-->>JS: Returns payload (instructions to display)
+    
+    JS->>User: Displays instructions inline to tell user what to do
+    
+    JS->>HA_SSE: Immediately initiates EventSource request
+    HA_SSE-->>JS: SSE stream opened
+    
+    par Backend Processing
+        Note over Worker: Handles state changes, IdP polling,<br/>and broadcasts to components
+        Worker->>Worker: Flow completes successfully
+        Worker->>HA_SSE: Broadcasts state change
+    and Frontend Waiting
+        loop Keep-Alive ping
+            HA_SSE-->>JS: event: waiting
+        end
+    end
+    
+    HA_SSE-->>JS: event: ready (Final Payload)
+    JS->>JS: Handles client redirect using final payload
+```
 


### PR DESCRIPTION
Fixes #300 

This is a draft PR to refactor the existing device code functionality to enable support for external IdP device code flows. This PR is focused on setting the backend foundation—including endpoint restructuring and internal state management—for the device auth flow. While highly specialized frontend routing logic will be deferred to later PRs, this PR establishes the bedrock: cleanly separating normal OAuth/OIDC flows from device code flows. 

Specifically, this PR introduces new `/auth/oidc/*` endpoints to handle the device code fallback locally (in case the IdP does not support device codes) and establishes a decoupled Server-Sent Events (SSE) pattern. By using SSE, our custom JS frontend on the Welcome Screen can seamlessly listen for backend state changes while an abstracted backend worker handles the actual polling of the IdP (e.g., Authentik). Standard HTTP polling of the device endpoint is also supported as a fallback to future-proof for third-party clients.

> [!NOTE]
> This PR will not address discussion #350 at this time and will be followed up in a separate PR.

## Proposed endpoints:

- `/auth/oidc/device` (GET): Endpoint that the user is directed to on a secondary device to enter the activation code (fallback for when IdP device code flow is unavailable). This requires the user to get authorized through the normal OAuth/OIDC flow first.
- `/auth/oidc/device` (POST): Endpoint for the client to explicitly initiate the device code flow after UX routing logic completes. This triggers the backend to begin background polling with the IdP and provides the client with a session token cookie. The client may also use this endpoint to poll for the status of the device code flow in line to the OIDC standard for device code flows. However, SSE is the preferred method for clients that are running the front end code provided by this integration.
- `/auth/oidc/device-sse` (GET): Endpoint the client connects to for Server-Sent Events (SSE) after initiation. The backend matches the request based on the session token cookie provided by the initiation POST request. A direct request to this endpoint without the device flow being initiated will be rejected.
- `/auth/oidc/redirect`: Remains functionally the same, except that it is explicitly chosen by the frontend UX logic. The backend remains agnostic to the flow type; it relies on the frontend to route accordingly based on device detection or user input.

## PR Context

This PR is supposed to address issue #300 and move discussion from #349 to this PR. Furthermore, this proposal is preliminary and will be updated as I further research the codebase.

## Decoupled Device Flow Diagram

The following sequence diagram illustrates how the frontend SSE connection is decoupled from the actual background polling task (which handles either the external IdP device flow or the internal fallback flow).

```mermaid
sequenceDiagram
    actor User
    participant JS as JS Frontend (Welcome Screen)
    participant HA_Dev as POST /auth/oidc/device
    participant Worker as Backend Worker
    participant HA_SSE as GET /auth/oidc/device-sse
    
    Note over User, JS: User is redirected to authenticate and brought to Welcome screen.
    
    User->>JS: Selects "Device Code" login flow
    
    JS->>HA_Dev: Initiates POST request
    HA_Dev->>Worker: Sets status in DB & spawns worker
    HA_Dev-->>JS: Returns payload (instructions to display)
    
    JS->>User: Displays instructions inline to tell user what to do
    
    JS->>HA_SSE: Immediately initiates EventSource request
    HA_SSE-->>JS: SSE stream opened
    
    par Backend Processing
        Note over Worker: Handles state changes, IdP polling,<br/>and broadcasts to components
        Worker->>Worker: Flow completes successfully
        Worker->>HA_SSE: Broadcasts state change
    and Frontend Waiting
        loop Keep-Alive ping
            HA_SSE-->>JS: event: waiting
        end
    end
    
    HA_SSE-->>JS: event: ready (Final Payload)
    JS->>JS: Handles client redirect using final payload
```

